### PR TITLE
fix(leaderboards.referrer): use production ENSNode URL

### DIFF
--- a/ensawards.org/src/components/holiday-referral-awards/referrers/ReferrersPaginatedDisplay.tsx
+++ b/ensawards.org/src/components/holiday-referral-awards/referrers/ReferrersPaginatedDisplay.tsx
@@ -24,10 +24,10 @@ export function ReferrersPaginatedDisplay({ itemsPerPage = 25 }: ReferrersPagina
     useState<ReferrerLeaderboardPage | null>(null);
   const ensNodeUrl = getENSNodeUrl();
   const client = new ENSNodeClient({
-    url: ensNodeUrl
+    url: ensNodeUrl,
   });
   const ensNodeReactConfig = createConfig({
-    url: ensNodeUrl
+    url: ensNodeUrl,
   });
 
   //TODO: Ideally that part could also be extracted (with useQuery or w/e)


### PR DESCRIPTION
This PR updates ENSNode URLs to always point to the ENSNode production instance. 