### PR TITLE
fix(leaderboards.referrer): use production ENSNode URL

### DIFF
--- a/ensawards.org/src/components/holiday-referral-awards/referrers/TopReferrers.tsx
+++ b/ensawards.org/src/components/holiday-referral-awards/referrers/TopReferrers.tsx
@@ -23,13 +23,13 @@ export function TopReferrers({
   const [isLoading, setIsLoading] = useState(false);
   const [fetchErrorMessage, setFetchErrorMessage] = useState("");
   const [topReferrersData, setTopReferrersData] = useState<ReferrerLeaderboardPage | null>(null);
+  const ensNodeUrl = getENSNodeUrl();
   const client = new ENSNodeClient({
-    url: new URL("https://api.alpha.blue.ensnode.io/"), //TODO: replace with the line below later on
-    // url: getENSNodeUrl(),
+    url: ensNodeUrl,
   });
   const ensNodeReactConfig = createConfig({
-    url: "https://api.alpha.blue.ensnode.io/",
-  }); //TODO: replace with getENSNodeUrl for prod
+    url: ensNodeUrl,
+  });
 
   //TODO: Ideally that part could also be extracted (with useQuery or w/e)
   // so that we can do something similar like we do with ENSNodeConfigInfo in ENSAdmin


### PR DESCRIPTION
Follow up to #89 