### PR TITLE
Fix Twitter Card's image display

### DIFF
--- a/ensawards.org/src/data/apps.ts
+++ b/ensawards.org/src/data/apps.ts
@@ -41,7 +41,7 @@ export const APPS: App[] = [
       },
     ],
     ogImagePath: "/app-rainbow-wallet_og_image.png",
-    twitterOgImagePath: "/app-rainbow-wallet_twitter_og_image.png",
+    twitterOgImagePath: "https://ensawards.org/app-rainbow-wallet_twitter_og_image.png",
   },
   {
     id: "coinbase-wallet",
@@ -77,7 +77,7 @@ export const APPS: App[] = [
       },
     ],
     ogImagePath: "/app-coinbase-wallet_og_image.png",
-    twitterOgImagePath: "/app-coinbase-wallet_twitter_og_image.png",
+    twitterOgImagePath: "https://ensawards.org/app-coinbase-wallet_twitter_og_image.png",
   },
   {
     id: "metamask",
@@ -112,7 +112,7 @@ export const APPS: App[] = [
       },
     ],
     ogImagePath: "/app-metamask_og_image.png",
-    twitterOgImagePath: "/app-metamask_twitter_og_image.png",
+    twitterOgImagePath: "https://ensawards.org/app-metamask_twitter_og_image.png",
   },
   {
     id: "etherscan",
@@ -147,7 +147,7 @@ export const APPS: App[] = [
       },
     ],
     ogImagePath: "/app-etherscan_og_image.png",
-    twitterOgImagePath: "/app-etherscan_twitter_og_image.png",
+    twitterOgImagePath: "https://ensawards.org/app-etherscan_twitter_og_image.png",
   },
   {
     id: "blockscout",
@@ -181,6 +181,6 @@ export const APPS: App[] = [
       },
     ],
     ogImagePath: "/app-blockscout_og_image.png",
-    twitterOgImagePath: "/app-blockscout_twitter_og_image.png",
+    twitterOgImagePath: "https://ensawards.org/app-blockscout_twitter_og_image.png",
   },
 ];

--- a/ensawards.org/src/data/organizations.ts
+++ b/ensawards.org/src/data/organizations.ts
@@ -29,7 +29,7 @@ export const ENSDaoOrg: Organization = {
     ens: "ensdao.eth",
   },
   ogImagePath: "/org-ens-dao_og_image.png",
-  twitterOgImagePath: "/org-ens-dao_twitter_og_image.png",
+  twitterOgImagePath: "https://ensawards.org/org-ens-dao_twitter_og_image.png",
 };
 
 export const UniswapDaoOrg: Organization = {
@@ -47,7 +47,7 @@ export const UniswapDaoOrg: Organization = {
     ens: "uniswap.eth",
   },
   ogImagePath: "/org-uniswap-dao_og_image.png",
-  twitterOgImagePath: "/org-uniswap-dao_twitter_og_image.png",
+  twitterOgImagePath: "https://ensawards.org/org-uniswap-dao_twitter_og_image.png",
 };
 
 export const NounsDaoOrg: Organization = {
@@ -65,7 +65,7 @@ export const NounsDaoOrg: Organization = {
     ens: "nouns.eth",
   },
   ogImagePath: "/org-nouns-dao_og_image.png",
-  twitterOgImagePath: "/org-nouns-dao_twitter_og_image.png",
+  twitterOgImagePath: "https://ensawards.org/org-nouns-dao_twitter_og_image.png",
 };
 
 export const ArbitrumDaoOrg: Organization = {
@@ -82,7 +82,7 @@ export const ArbitrumDaoOrg: Organization = {
     twitter: new URL("https://x.com/arbitrum"),
   },
   ogImagePath: "/org-arbitrum-dao_og_image.png",
-  twitterOgImagePath: "/org-arbitrum-dao_twitter_og_image.png",
+  twitterOgImagePath: "https://ensawards.org/org-arbitrum-dao_twitter_og_image.png",
 };
 
 export const AaveDaoOrg: Organization = {
@@ -100,7 +100,7 @@ export const AaveDaoOrg: Organization = {
     ens: "aave.eth",
   },
   ogImagePath: "/org-aave-dao_og_image.png",
-  twitterOgImagePath: "/org-aave-dao_twitter_og_image.png",
+  twitterOgImagePath: "https://ensawards.org/org-aave-dao_twitter_og_image.png",
 };
 
 export const TaikoDaoOrg: Organization = {
@@ -118,7 +118,7 @@ export const TaikoDaoOrg: Organization = {
     ens: "taiko.eth",
   },
   ogImagePath: "/org-taiko-dao_og_image.png",
-  twitterOgImagePath: "/org-taiko-dao_twitter_og_image.png",
+  twitterOgImagePath: "https://ensawards.org/org-taiko-dao_twitter_og_image.png",
 };
 
 /**

--- a/ensawards.org/src/layouts/Layout.astro
+++ b/ensawards.org/src/layouts/Layout.astro
@@ -25,7 +25,7 @@ const DEFAULT_TITLE = "ENSAwards: ENS leaderboards and best practices";
 const DEFAULT_DESCRIPTION = "Awarding the best in ENS.";
 const DEFAULT_URL = "https://ensawards.org/";
 const DEFAULT_OG_IMAGE = "/default_og_image.png";
-const DEFAULT_TWITTER_IMAGE = "/default_twitter_og_image.png";
+const DEFAULT_TWITTER_IMAGE = "https://ensawards.org/default_twitter_og_image.png";
 
 const DEFAULT_PAGE_METADATA: PageMetadata = {
   title: DEFAULT_TITLE,
@@ -84,6 +84,7 @@ const { isStatic = false, pageMetadata = DEFAULT_PAGE_METADATA }: LayoutProps = 
         image: pageMetadata.twitterImage || DEFAULT_TWITTER_IMAGE,
         description: pageMetadata.description || DEFAULT_DESCRIPTION,
         card: "summary_large_image",
+        site: "@NameHashLabs",
       }}
       extend={{
         link: [

--- a/ensawards.org/src/pages/ens-contract-naming-season.astro
+++ b/ensawards.org/src/pages/ens-contract-naming-season.astro
@@ -154,7 +154,7 @@ const daoScores = contractPipeline({
     description: "Elevate your protocol’s onchain identity.",
     url: "https://ensawards.org/ens-contract-naming-season",
     ogImage: "/contract-naming-season_og_image.png",
-    twitterImage: "/contract-naming-season_twitter_og_image.png",
+    twitterImage: "https://ensawards.org/contract-naming-season_twitter_og_image.png",
   }}>
   <ContractNamingHero />
   <section

--- a/ensawards.org/src/pages/ens-holiday-awards-rules.astro
+++ b/ensawards.org/src/pages/ens-holiday-awards-rules.astro
@@ -20,7 +20,7 @@ const termStyles =
       "Trial incentive framework for a broader ENS Referral Awards Program.",
     url: "https://ensawards.org/ens-holiday-awards-rules",
     ogImage: "/holiday-referral-awards_og_image.png",
-    twitterImage: "/holiday-referral-awards_twitter_og_image.png",
+    twitterImage: "https://ensawards.org/holiday-referral-awards_twitter_og_image.png",
   }}>
   <SubpageHero
     header="ENS Holiday Awards - Program Rules"

--- a/ensawards.org/src/pages/ens-referral-awards.astro
+++ b/ensawards.org/src/pages/ens-referral-awards.astro
@@ -71,7 +71,7 @@ const backgroundGreyStyles =
       "Earn rewards for referring .eth name registrations and renewals. Join the ENS Holiday Awards program.",
     url: "https://ensawards.org/ens-referral-awards",
     ogImage: "/holiday-referral-awards_og_image.png",
-    twitterImage: "/holiday-referral-awards_twitter_og_image.png",
+    twitterImage: "https://ensawards.org/holiday-referral-awards_twitter_og_image.png",
   }}>
   <HolidayReferralAwardsHero />
   <section

--- a/ensawards.org/src/pages/leaderboards/app.astro
+++ b/ensawards.org/src/pages/leaderboards/app.astro
@@ -23,7 +23,7 @@ const placeIcons = [
     description: "See how apps score on ENS integration benchmarks.",
     url: "https://ensawards.org/leaderboards/app",
     ogImage: "/app_leaderboard_og_image.png",
-    twitterImage: "/app_leaderboard_twitter_og_image.png",
+    twitterImage: "https://ensawards.org/app_leaderboard_twitter_og_image.png",
   }}>
   <SubpageHero
     header="App leaderboard"

--- a/ensawards.org/src/pages/leaderboards/dao.astro
+++ b/ensawards.org/src/pages/leaderboards/dao.astro
@@ -32,7 +32,7 @@ const placeIcons = [
     description: "See how DAOs score on ENS integration benchmarks.",
     url: "https://ensawards.org/leaderboards/dao",
     ogImage: "/dao_leaderboard_og_image.png",
-    twitterImage: "/dao_leaderboard_twitter_og_image.png",
+    twitterImage: "https://ensawards.org/dao_leaderboard_twitter_og_image.png",
   }}>
   <SubpageHero
     header="DAO leaderboard"

--- a/ensawards.org/src/pages/leaderboards/index.astro
+++ b/ensawards.org/src/pages/leaderboards/index.astro
@@ -34,7 +34,7 @@ const referrerLeaderboardDescription =
       "Compare projects by their rank of following a selection of ENS best practices.",
     url: "https://ensawards.org/leaderboards",
     ogImage: "/ens_leaderboards_og_image.png",
-    twitterImage: "/ens_leaderboards_twitter_og_image.png",
+    twitterImage: "https://ensawards.org/ens_leaderboards_twitter_og_image.png",
   }}>
   <SubpageHero
     header="ENS leaderboards"

--- a/ensawards.org/src/pages/leaderboards/referrer.astro
+++ b/ensawards.org/src/pages/leaderboards/referrer.astro
@@ -11,7 +11,7 @@ import Layout from "../../layouts/Layout.astro";
       "Compare referrers by their performance in ENS Holiday Awards.",
     url: "https://ensawards.org/leaderboards/referrer",
     ogImage: "/referrer_leaderboard_og_image.png",
-    twitterImage: "/referrer_leaderboard_twitter_og_image.png",
+    twitterImage: "https://ensawards.org/referrer_leaderboard_twitter_og_image.png",
   }}>
   <SubpageHero
     header="ENS Referral Leaderboard"


### PR DESCRIPTION
# Issue

After pasting the ensawards.org-related link in `TweetComposer` or even when posting the tweet, the card preview loaded just fine, but without the preview image.

# Performed checks

* I made sure that the og images work on `facebook`, `slack`, `discord` and `telegram`
* I checked the card's preview with Vercel preview tools, an external tool [opengraph.xyz](https://www.opengraph.xyz/url/https%3A%2F%2Fensawards.org%2Fens-referral-awards%23live-feed), and the official [twitter card validator](https://cards-dev.x.com/validator) (posting the check result as a screenshot below) &rarr; they all indicated that the preview should work (with the image)
* As the official troubleshooting docs (both the [forum post](https://devcommunity.x.com/t/card-error-unable-to-render-or-no-image-read-this-first/62736) and the [official troubleshooting guide](https://developer.x.com/en/docs/x-for-websites/cards/guides/troubleshooting-cards#twitterbot)) suggested I:
    * Checked the page's SLL with a [recommended tool](https://www.ssllabs.com/ssltest/analyze.html?d=ensawards.org) (also posting a screenshot below)
    * Confirmed that all required metadata tags are included in the page's head and that they are static
    * Ran the `curl -v -A Twitterbot https://ensawards.org/ens-referral-awards#live-feed` command and confirmed that it returns a valid response that includes all necessary metadata tags (including the `twitter:image` tag with its content)
    * Double-checked that our OG images satisfy official requirements:
        - [x] Aspect ratio 2:1 (4096x2048 dimensions &rarr; correct)
        - [x] Minimum dimensions of 300x157 or maximum of 4096x4096 pixels (4096x2048 dimensions &rarr; correct)
        - [x] Less than 5MB in size (sizes between 1.73-4.45MB, including 1,73MB size of the referral-related page X's OG image)
        - [x] JPG, PNG, WEBP and GIF formats are supported (we use PNG &rarr; correct)
    * Confirmed that OG images are publicly available ex. at https://ensawards.org/holiday-referral-awards_twitter_og_image.png
    * Confirmed that our `robots.txt` file allows Twitterbot to crawl the page
    * Tried to force crawler's update by using a bit.ly link &rarr; without success
* I also checked our Vercel environment for the activity of the Twitterbot but found none (which is not sufficient proof in itself, but I'll still post a video-proof), and confirmed that the Vercel deployment itself doesn't block any bots (including Twitterbot) from accessing our page.

# Attempted fix
As a last resort, I asked chatGPT to have a look at our metadata tags, and it suggested that the issue might lie in the relative paths to the OG images. It suggested to swap the paths to absolute URLs, and that's what I did in this PR.

I've also added a correct `twitter:site` metadata tag, but I suppose it won't be relevant as it is marked as not required in [Twitter's docs](https://developer.x.com/en/docs/x-for-websites/cards/overview/summary-card-with-large-image)

# Relevant screenshots

<img width="1340" height="745" alt="Zrzut ekranu 2025-12-12 093357" src="https://github.com/user-attachments/assets/cf659681-9826-4331-8dc7-89818ac2037d" />
<img width="1469" height="868" alt="Zrzut ekranu 2025-12-11 170517" src="https://github.com/user-attachments/assets/3fdd711d-1d49-4b72-8fd3-54bb18a68b04" />
<img width="736" height="770" alt="Zrzut ekranu 2025-12-11 164948" src="https://github.com/user-attachments/assets/0fe235ef-0709-4251-9a48-e97ad80bcb95" />
<img width="1194" height="461" alt="Zrzut ekranu 2025-12-12 093853" src="https://github.com/user-attachments/assets/860c88be-ff63-4989-a191-f5da27a132c7" />
