### PR TITLE
(Lite) Update resolution status of Nouns DAO contracts

### DIFF
--- a/ensawards.org/src/data/contracts.ts
+++ b/ensawards.org/src/data/contracts.ts
@@ -342,7 +342,7 @@ export const CONTRACTS: Contract[] = [
     type: ContractTypes.Dao,
     subtype: ContractSubtypes.DefiApp,
     cachedIdentity: {
-      resolutionStatus: ContractResolutionStatusIds.ForwardNamed,
+      resolutionStatus: ContractResolutionStatusIds.PrimaryNamed,
       name: "auction.nouns.eth",
       contract: {
         address: "0x830BD73E4184ceF73443C15111a1DF14e495C706",
@@ -356,7 +356,7 @@ export const CONTRACTS: Contract[] = [
     type: ContractTypes.Dao,
     subtype: ContractSubtypes.Governance,
     cachedIdentity: {
-      resolutionStatus: ContractResolutionStatusIds.ForwardNamed,
+      resolutionStatus: ContractResolutionStatusIds.PrimaryNamed,
       name: "candidates.nouns.eth",
       contract: {
         address: "0xf790A5f59678dd733fb3De93493A91f472ca1365",
@@ -370,7 +370,7 @@ export const CONTRACTS: Contract[] = [
     type: ContractTypes.Dao,
     subtype: ContractSubtypes.Governance,
     cachedIdentity: {
-      resolutionStatus: ContractResolutionStatusIds.ForwardNamed,
+      resolutionStatus: ContractResolutionStatusIds.PrimaryNamed,
       name: "delegations.nouns.eth",
       contract: {
         address: "0x9c8ff314c9bc7f6e59a9d9225fb22946427edc03",
@@ -398,7 +398,7 @@ export const CONTRACTS: Contract[] = [
     type: ContractTypes.Dao,
     subtype: ContractSubtypes.DefiApp,
     cachedIdentity: {
-      resolutionStatus: ContractResolutionStatusIds.ForwardNamed,
+      resolutionStatus: ContractResolutionStatusIds.PrimaryNamed,
       name: "rewards.nouns.eth",
       contract: {
         address: "0x883860178F95d0C82413eDc1D6De530cB4771d55",
@@ -412,7 +412,7 @@ export const CONTRACTS: Contract[] = [
     type: ContractTypes.Dao,
     subtype: ContractSubtypes.DefiApp,
     cachedIdentity: {
-      resolutionStatus: ContractResolutionStatusIds.ForwardNamed,
+      resolutionStatus: ContractResolutionStatusIds.PrimaryNamed,
       name: "traits.nouns.eth",
       contract: {
         address: "0x33A9c445fb4FB21f2c030A6b2d3e2F12D017BFAC",


### PR DESCRIPTION
Updates `resolutionStatus` field for 5 `Nouns DAO`'s contracts to make our data up-to-date again. Satisfies [this lightwalker's request on Slack](https://namehash.slack.com/archives/C086Z6FNBHN/p1766495798154899?thread_ts=1766495468.344209&cid=C086Z6FNBHN). 

All contracts' statuses were double-checked with the ENS manager app, Etherscan, and most importantly, enscribe. 

Updated contracts are:
- [x] [auction.nouns.eth](https://app.enscribe.xyz/explore/1/auction.nouns.eth)
- [x] [candidates.nouns.eth](https://app.enscribe.xyz/explore/1/candidates.nouns.eth)
- [x] [delegations.nouns.eth](https://app.enscribe.xyz/explore/1/delegations.nouns.eth)
- [x] [rewards.nouns.eth](https://app.enscribe.xyz/explore/1/rewards.nouns.eth)
- [x] [traits.nouns.eth](https://app.enscribe.xyz/explore/1/traits.nouns.eth)

The other forward-named-only contracts were confirmed to still be in that status on `enscribe`'s page. See screenshots below
<img width="710" height="393" alt="image" src="https://github.com/user-attachments/assets/f01d010e-17b7-407b-98f9-9c464492ffcb" />

<img width="710" height="482" alt="Zrzut ekranu 2025-12-29 093107" src="https://github.com/user-attachments/assets/296bb0b1-8efe-4aa2-b38b-1601fd1f5727" />
