### PR TITLE
chore: Refactor `*.content` field of `BestPractice`

### DIFF
--- a/ensawards.org/data/ens-best-practices/contract-naming/display-named-smart-contracts-l2-chains.ts
+++ b/ensawards.org/data/ens-best-practices/contract-naming/display-named-smart-contracts-l2-chains.ts
@@ -1,6 +1,25 @@
 import { AppTypes } from "../../apps/types.ts";
 import { type BestPracticeApp, BestPracticeTypes } from "../types.ts";
 
+const technicalDetailsMainContent = `When users interact with a contract on an L2 chain, use the 
+[ENSIP-19](https://docs.ens.domains/ensip/19) standard to lookup the primary name of the contract. 
+ENSIP-19 provides chain-specific primary names for L2 networks (including Optimism, Arbitrum, Base, 
+Linea, and Scroll), with an automatic fallback to a default primary name (defined on mainnet) if no 
+chain-specific primary name is defined. There are several libraries to choose from that support 
+ENSIP-19 and all ENS best practices:
+- [ensnode-sdk](https://github.com/namehash/ensnode/blob/main/packages/ensnode-sdk/README.md) (v1.0.0+)
+- [ensnode-react](https://github.com/namehash/ensnode/blob/main/packages/ensnode-react/README.md) (v1.0.0+)
+- [Viem](https://viem.sh/docs/ens/actions/getEnsName#chain-specific-resolution) (v2.35.0+)
+- [Wagmi](https://wagmi.sh/react/api/hooks/useEnsName#chainid) (v2.18.0+)
+Libraries and tools for additional languages or frameworks can be found in the [ENS documentation](https://docs.ens.domains/web/libraries/).`;
+
+const technicalDetailsAdditionalContent = `ENSIP-19 enables primary names to be set on any chain. 
+Contracts deployed to an L2 chain benefit from this, as the contract can then configure its name 
+directly on the chain it is deployed to without any need to update state on mainnet. If a contract 
+has an ENS name, you can use the contract's ENS profile to power additional UX improvements such as 
+displaying the contract's avatar, metadata, audit information, and more. More information can be found 
+at [this ENSIP](https://discuss.ens.domains/t/ensip-proposal-contract-metadata-standard-and-text-records/21397).`;
+
 export const displayNamedSmartContractsL2: BestPracticeApp = {
   type: BestPracticeTypes.App,
   id: "display-named-smart-contracts-l2-chains",
@@ -14,24 +33,12 @@ export const displayNamedSmartContractsL2: BestPracticeApp = {
   technicalDetails: {
     main: {
       header: "Technical Details",
-      content:
-        "When users interact with a contract on an L2 chain, use the [ENSIP-19](https://docs.ens.domains/ensip/19) standard to lookup the primary name of the contract. " +
-        "ENSIP-19 provides chain-specific primary names for L2 networks (including Optimism, Arbitrum, Base, Linea, and Scroll), with an automatic fallback to a default primary name (defined on mainnet) if no chain-specific primary name is defined. " +
-        "There are several libraries to choose from that support ENSIP-19 and all ENS best practices: \n" +
-        "- [ensnode-sdk](https://github.com/namehash/ensnode/blob/main/packages/ensnode-sdk/README.md) (v1.0.0+)\n" +
-        "- [ensnode-react](https://github.com/namehash/ensnode/blob/main/packages/ensnode-react/README.md) (v1.0.0+)\n" +
-        "- [Viem](https://viem.sh/docs/ens/actions/getEnsName#chain-specific-resolution) (v2.35.0+)\n" +
-        "- [Wagmi](https://wagmi.sh/react/api/hooks/useEnsName#chainid) (v2.18.0+)\n" +
-        "Libraries and tools for additional languages or frameworks can be found in the [ENS documentation](https://docs.ens.domains/web/libraries/).",
+      content: technicalDetailsMainContent,
     },
     sides: [
       {
         header: "Additional Details",
-        content:
-          "ENSIP-19 enables primary names to be set on any chain. " +
-          "Contracts deployed to an L2 chain benefit from this, as the contract can then configure its name directly on the chain it is deployed to without any need to update state on mainnet. " +
-          "If a contract has an ENS name, you can use the contract's ENS profile to power additional UX improvements such as displaying the contract's avatar, metadata, audit information, and more. " +
-          "More information can be found at [this ENSIP](https://discuss.ens.domains/t/ensip-proposal-contract-metadata-standard-and-text-records/21397).",
+        content: technicalDetailsAdditionalContent,
       },
     ],
   },

--- a/ensawards.org/data/ens-best-practices/contract-naming/display-named-smart-contracts-mainnet.ts
+++ b/ensawards.org/data/ens-best-practices/contract-naming/display-named-smart-contracts-mainnet.ts
@@ -1,6 +1,18 @@
 import { AppTypes } from "../../apps/types.ts";
 import { type BestPracticeApp, BestPracticeTypes } from "../types.ts";
 
+const technicalDetailsMainContent = `Looking up the name of a smart contract on Ethereum mainnet uses the same process as looking up the name of any other account. 
+There are a variety of libraries capable of looking up the [primary name](https://docs.ens.domains/web/reverse) of a contract address according to all ENS best practices:
+- [ensnode-sdk](https://github.com/namehash/ensnode/blob/main/packages/ensnode-sdk/README.md) (v1.0.0+)
+- [ensnode-react](https://github.com/namehash/ensnode/blob/main/packages/ensnode-react/README.md) (v1.0.0+)
+- [Viem](https://viem.sh/docs/ens/actions/getEnsName#chain-specific-resolution) (v2.35.0+)
+- [Wagmi](https://wagmi.sh/react/api/hooks/useEnsName#chainid) (v2.18.0+)
+Libraries and tools for additional languages or frameworks can be found in the [ENS documentation](https://docs.ens.domains/web/libraries/).`;
+
+const technicalDetailsAdditionalContent = `If a contract has an ENS name, you can use its ENS profile to power additional UX improvements 
+such as avatars, metadata, audit information, and more. More information can be found at the 
+[ENSIP Proposal](https://discuss.ens.domains/t/ensip-proposal-contract-metadata-standard-and-text-records/21397).`;
+
 export const displayNamedSmartContractsMainnet: BestPracticeApp = {
   type: BestPracticeTypes.App,
   id: "display-named-smart-contracts-mainnet",
@@ -14,21 +26,12 @@ export const displayNamedSmartContractsMainnet: BestPracticeApp = {
   technicalDetails: {
     main: {
       header: "Technical Details",
-      content:
-        "Looking up the name of a smart contract on Ethereum mainnet uses the same process as looking up the name of any other account. " +
-        "There are a variety of libraries capable of looking up the [primary name](https://docs.ens.domains/web/reverse) of a contract address according to all ENS best practices:\n" +
-        "- [ensnode-sdk](https://github.com/namehash/ensnode/blob/main/packages/ensnode-sdk/README.md) (v1.0.0+)\n" +
-        "- [ensnode-react](https://github.com/namehash/ensnode/blob/main/packages/ensnode-react/README.md) (v1.0.0+)\n" +
-        "- [Viem](https://viem.sh/docs/ens/actions/getEnsName#chain-specific-resolution) (v2.35.0+)\n" +
-        "- [Wagmi](https://wagmi.sh/react/api/hooks/useEnsName#chainid) (v2.18.0+)\n" +
-        "Libraries and tools for additional languages or frameworks can be found in the [ENS documentation](https://docs.ens.domains/web/libraries/).",
+      content: technicalDetailsMainContent,
     },
     sides: [
       {
         header: "Additional Details",
-        content:
-          "If a contract has an ENS name, you can use its ENS profile to power additional UX improvements such as avatars, metadata, audit information, and more. " +
-          "More information can be found at the [ENSIP Proposal](https://discuss.ens.domains/t/ensip-proposal-contract-metadata-standard-and-text-records/21397).",
+        content: technicalDetailsAdditionalContent,
       },
     ],
   },

--- a/ensawards.org/data/ens-best-practices/contract-naming/name-your-smart-contracts.ts
+++ b/ensawards.org/data/ens-best-practices/contract-naming/name-your-smart-contracts.ts
@@ -1,5 +1,16 @@
 import { type BestPracticeProtocol, BestPracticeTypes, ProtocolTypes } from "../types.ts";
 
+const technicalDetailsMainContent = `Contracts should be [assigned ENS names](https://docs.ens.domains/web/naming-contracts/) during or after deployment. 
+For deployment-time naming, see the [Enscribe documentation](https://www.enscribe.xyz/docs/introduction/naming-contracts) which goes into greater detail on the process. 
+For post-deployment naming we recommend using the [Enscribe App](https://app.enscribe.xyz/). 
+Note that setting a [primary name](https://docs.ens.domains/web/reverse) (reverse resolution) requires the contract to implement 
+[Ownable](https://docs.openzeppelin.com/contracts/5.x/access-control#ownership-and-ownable). 
+Contracts without Ownable can still have forward resolution configured (\`name → address\`) but cannot set a reverse record (\`address → name\`).`;
+
+const technicalDetailsAdditionalContent = `Assigning ENS names to contracts gives users confidence they're interacting with the correct contract. 
+This is particularly valuable for security, as users can confirm \`uniswap.eth\` instead of validating a long hexadecimal address. 
+If you've deployed contracts without Ownable, you can still improve UX by configuring forward resolution, though full naming (with reverse resolution) provides the best user experience.`;
+
 export const nameYourSmartContracts: BestPracticeProtocol = {
   type: BestPracticeTypes.Protocol,
   id: "name-your-smart-contracts",
@@ -12,20 +23,12 @@ export const nameYourSmartContracts: BestPracticeProtocol = {
   technicalDetails: {
     main: {
       header: "Technical Details",
-      content:
-        "Contracts should be [assigned ENS names](https://docs.ens.domains/web/naming-contracts/) during or after deployment. " +
-        "For deployment-time naming, see the [Enscribe documentation](https://www.enscribe.xyz/docs/introduction/naming-contracts) which goes into greater detail on the process. " +
-        "For post-deployment naming we recommend using the [Enscribe App](https://app.enscribe.xyz/). " +
-        "Note that setting a [primary name](https://docs.ens.domains/web/reverse) (reverse resolution) requires the contract to implement [Ownable](https://docs.openzeppelin.com/contracts/5.x/access-control#ownership-and-ownable). " +
-        "Contracts without Ownable can still have forward resolution configured (`name → address`) but cannot set a reverse record (`address → name`).",
+      content: technicalDetailsMainContent,
     },
     sides: [
       {
         header: "Additional Details",
-        content:
-          "Assigning ENS names to contracts gives users confidence they're interacting with the correct contract. " +
-          "This is particularly valuable for security, as users can confirm `uniswap.eth` instead of validating a long hexadecimal address. " +
-          "If you've deployed contracts without Ownable, you can still improve UX by configuring forward resolution, though full naming (with reverse resolution) provides the best user experience.",
+        content: technicalDetailsAdditionalContent,
       },
     ],
   },

--- a/ensawards.org/data/ens-best-practices/forward-resolution/recognize-all-ens-names.ts
+++ b/ensawards.org/data/ens-best-practices/forward-resolution/recognize-all-ens-names.ts
@@ -1,6 +1,25 @@
 // TODO: In a future PR uncomment recognizeAllENSNames best practice
+
+// // Using an approach of practical steps of how to implement with authoritative links with more details
+// const technicalDetailsMainContent = `To properly support all valid ENS names, your application should implement a structured validation approach.
+// Begin by handling empty input cases by prompting users to enter an ENS name or address.
+// Then verify if the input represents an address format using a library such as [Viem](https://viem.sh/docs/utilities/isAddress), treating it as an address if valid.
+// For non-address inputs, determine if the input can be normalized as an ENS name using \`ens_normalize\` from [ENSIP-15](https://docs.ens.domains/ensip/15).
+// When \`ens_normalize\` executes without throwing an error, the input is considered normalizable (meaning normalization succeeds), which differs from being normalized (where input equals output).
+// Then you should process the normalized result as the canonical ENS name representation.
+// Libraries including [Viem](https://viem.sh/docs/ens/utilities/normalize),
+// [ensjs](https://github.com/ensdomains/ensjs/blob/8b4c34840cdef8828961453554e12aea8c9bfe83/packages/ensjs/src/utils/normalise.ts#L34)
+// and [ens-normalize.js](https://github.com/adraffy/ens-normalize.js) provide \`ens_normalize\` implementations,
+// with additional options available in the [ENS Documentation](https://docs.ens.domains/web/libraries).
+// Finally, display an appropriate error message when input fails validation as either a valid name or address. `;
 //
-// export const recognizeAllENSNames: BestPractice = {
+// // I'm using https://ensnode.io/docs/ as the main reference point for our docs since it will remain a static path no matter what we update in our docs.
+// // Ideally our quickstart will become more robust and be perfect for a callout like this.
+// const technicalDetailsAdditionalContent = `Once you have properly implemented ENS name detection, consider adding more details and records to your app.
+// [ENSNode](https://ensnode.io/docs/) makes it simple and easy to fetch ENS profile data that can be used to enhance your user experience.
+// This could include avatars, social media profiles, links to website, and much more listed in the official [ENS documentation](https://docs.ens.domains/web).`;
+//
+// export const recognizeAllENSNames: BestPracticeApp = {
 //   id: "recognize-all-ens-names",
 //   bestPracticeSlug: "recognize-all-ens-names",
 //   name: "Recognize all valid ENS names",
@@ -11,25 +30,12 @@
 //   technicalDetails: {
 //     main: {
 //       header: "Technical Details",
-//       content:
-//         // Using an approach of practical steps of how to implement with authoritative links with more details
-//         "To properly support all valid ENS names, your application should implement a structured validation approach. " +
-//         "Begin by handling empty input cases by prompting users to enter an ENS name or address. " +
-//         "Then verify if the input represents an address format using a library such as [Viem](https://viem.sh/docs/utilities/isAddress), treating it as an address if valid. " +
-//         "For non-address inputs, determine if the input can be normalized as an ENS name using `ens_normalize` from [ENSIP-15](https://docs.ens.domains/ensip/15). " +
-//         "When `ens_normalize` executes without throwing an error, the input is considered normalizable (meaning normalization succeeds), which differs from being normalized (where input equals output). " +
-//         "Then you should process the normalized result as the canonical ENS name representation. " +
-//         "Libraries including [Viem](https://viem.sh/docs/ens/utilities/normalize), [ensjs](https://github.com/ensdomains/ensjs/blob/8b4c34840cdef8828961453554e12aea8c9bfe83/packages/ensjs/src/utils/normalise.ts#L34) and [ens-normalize.js](https://github.com/adraffy/ens-normalize.js) provide `ens_normalize` implementations, with additional options available in the [ENS Documentation](https://docs.ens.domains/web/libraries). " +
-//         "Finally, display an appropriate error message when input fails validation as either a valid name or address. ",
+//       content: technicalDetailsMainContent,
 //     },
 //     sides: [
 //       {
 //         header: "Additional Details",
-//         content:
-//           "Once you have properly implemented ENS name detection, consider adding more details and records to your app. " +
-//           // I'm using https://ensnode.io/docs/ as the main reference point for our docs since it will remain a static path no matter what we update in our docs. Ideally our quickstart will become more robust and be perfect for a callout like this.
-//           "[ENSNode](https://ensnode.io/docs/) makes it simple and easy to fetch ENS profile data that can be used to enhance your user experience. " +
-//           "This could include avatars, social media profiles, links to website, and much more listed in the official [ENS documentation](https://docs.ens.domains/web).",
+//         content: technicalDetailsAdditionalContent,
 //       },
 //     ],
 //   },


### PR DESCRIPTION
# Lite PR &rarr; Refactor `*.content` field of `BestPractice`

## Summary

- Moved technical details descriptions (`*.content` field inside `BestPractice.technicalDetails`) into separate multiline string variables to make editing (and reviewing those edits) easier in the future. This is applied to all best practices' definitions inside **`ensawards.org/data/ens-best-practices`**. For an example of that refactor, see **`ensawards.org/data/ens-best-practices/contract-naming/name-your-smart-contracts.ts`**

---

## Why

- See Issue #137

---

## Testing

- Ran `typecheck`, `lint` commands locally to confirm that the refactor didn't break anything
- Confirmed the observations from above with our remote CI workflow
- Inspected local and Vercel previews to confirm that UI wasn't affected by the refactor (as planned)

---

## Notes for Reviewer (Optional)

I think this approach helps a lot in terms of future editing.
However, I'm open to implementing other suggestions, if you have some

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
