### PR TITLE
Execute referral admin action

### DIFF
--- a/ensawards.org/public/production-editions-v1.10.0.json
+++ b/ensawards.org/public/production-editions-v1.10.0.json
@@ -37,7 +37,7 @@
         {
           "action": "Disqualification",
           "referrer": "0x9a75ed8e1e592c2e2b0d3eddee8404dcf326a8c5",
-          "reason": "Disqualified for April 2026 due to violation of rule 1 of the Code of Conduct. Unsatisfactory evidence that a preponderance of referrals are not self-referrals."
+          "reason": "Disqualified for April 2026 due to violation of rule 1 of the Code of Conduct. Insufficient evidence that most referrals were not self-referrals."
         }
       ]
     }

--- a/ensawards.org/public/production-editions-v1.10.0.json
+++ b/ensawards.org/public/production-editions-v1.10.0.json
@@ -33,7 +33,13 @@
       },
       "rulesUrl": "https://ensawards.org/ens-referral-program/editions/2026-04/rules",
       "areAwardsDistributed": false,
-      "adminActions": []
+      "adminActions": [
+        {
+          "action": "Disqualification",
+          "referrer": "0x9a75ed8e1e592c2e2b0d3eddee8404dcf326a8c5",
+          "reason": "Disqualified for April 2026 due to violation of rule 1 of the Code of Conduct. Unsatisfactory evidence that a preponderance of referrals are not self-referrals."
+        }
+      ]
     }
   },
   {

--- a/ensawards.org/public/production-editions.json
+++ b/ensawards.org/public/production-editions.json
@@ -32,7 +32,12 @@
       },
       "rulesUrl": "https://ensawards.org/ens-referral-program/editions/2026-04/rules",
       "areAwardsDistributed": false,
-      "disqualifications": []
+      "disqualifications": [
+        {
+          "referrer": "0x9a75ed8e1e592c2e2b0d3eddee8404dcf326a8c5",
+          "reason": "Disqualified for April 2026 due to violation of rule 1 of the Code of Conduct. Unsatisfactory evidence that a preponderance of referrals are not self-referrals."
+        }
+      ]
     }
   },
   {

--- a/ensawards.org/public/production-editions.json
+++ b/ensawards.org/public/production-editions.json
@@ -35,7 +35,7 @@
       "disqualifications": [
         {
           "referrer": "0x9a75ed8e1e592c2e2b0d3eddee8404dcf326a8c5",
-          "reason": "Disqualified for April 2026 due to violation of rule 1 of the Code of Conduct. Unsatisfactory evidence that a preponderance of referrals are not self-referrals."
+          "reason": "Disqualified for April 2026 due to violation of rule 1 of the Code of Conduct. Insufficient evidence that most referrals were not self-referrals."
         }
       ]
     }

--- a/ensawards.org/src/components/referral-awards-program/referrers/warnings/index.ts
+++ b/ensawards.org/src/components/referral-awards-program/referrers/warnings/index.ts
@@ -22,20 +22,10 @@ export const REFERRAL_PROGRAM_WARNINGS = new Map<
   [
     "2026-04",
     new Map<Address, ReferralProgramWarning>([
-      // TODO: Populate with true warnings.
-      // See https://github.com/namehash/ensawards/pull/174#discussion_r3058470915
-      // [
-      //   "0x7e491cde0fbf08e51f54c4fb6b9e24afbd18966d",
-      //   "This is a warning message for testing purposes.",
-      // ],
-      // [
-      //   "0xf919a96d2970380b87917b04f02e6d3d08368b10",
-      //   "This is a warning message for testing purposes.",
-      // ],
-      // [
-      //   "0x9c6aa5ce4903aad922ac4dde9b57817c1fc17d9b",
-      //   "This is a warning message for testing purposes.",
-      // ],
+      [
+        "0x02fa71cbb4b1b990a475deb370d0aa42aa43503b",
+        "A number of referrals for April 2026 are self-referrals. Continued self-referrals will violate rule 1 of the Code of Conduct and result in disqualification for April 2026.",
+      ],
     ]),
   ],
 ]);


### PR DESCRIPTION
Disqualification of enschile.eth from the April 2026 edition of the ENS Referral Program for violating rule 1 of the Code of Conduct and failing to provide satisfactory evidence that a preponderance of referrals are not self-referrals.