### PR TITLE
chore: Update `production-editions-v1.10.0` config file

### DIFF
--- a/ensawards.org/public/production-editions-v1.10.0.json
+++ b/ensawards.org/public/production-editions-v1.10.0.json
@@ -35,9 +35,14 @@
       "areAwardsDistributed": false,
       "adminActions": [
         {
-          "action": "Disqualification",
+          "actionType": "Disqualification",
           "referrer": "0x9a75ed8e1e592c2e2b0d3eddee8404dcf326a8c5",
           "reason": "Disqualified for April 2026 due to violation of rule 1 of the Code of Conduct. Insufficient evidence that most referrals were not self-referrals."
+        },
+        {
+          "actionType": "Warning",
+          "referrer": "0x02fa71cbb4b1b990a475deb370d0aa42aa43503b",
+          "reason": "A number of referrals for April 2026 are self-referrals. Continued self-referrals will violate rule 1 of the Code of Conduct and result in disqualification for April 2026."
         }
       ]
     }


### PR DESCRIPTION
# Lite PR &rarr; chore: Update `production-editions-v1.10.0` config file

## Summary

- Adds the admin warning (previously only added to **`ensawards.org\src\components\referral-awards-program\referrers\warnings\index.ts`**), as requested [here](https://namehash.slack.com/archives/C086Z6FNBHN/p1777065108561769?thread_ts=1777064940.596239&cid=C086Z6FNBHN)
- Fixes the incorrect name of one of the fields in the disqualification action where the field was labeled `action` instead of `actionType` &rarr; this should fix the 503 error that our `blue` instance currently throws for all referral-related endpoints (ex, https://api.alpha.blue.ensnode.io/v1/ensanalytics/editions)

<img width="1906" height="497" alt="image" src="https://github.com/user-attachments/assets/597235f0-f194-44e5-9a2b-5378b967b7d8" />

---

## Why

- Changes requested on Slack (thread linked above)

---

## Testing

- Will be tested in PR #195 after the EnsApi server is restarted for our `blue` instance

---

## Notes for Reviewer (Optional)

- Would be great to restart the EnsApi server on Alpha blue after this PR is merged

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
