### PR TITLE
chore: Adapt `production-editions.json` to ensnode v1.10.0

### DIFF
--- a/ensawards.org/public/production-editions.json
+++ b/ensawards.org/public/production-editions.json
@@ -4,7 +4,7 @@
     "displayName": "ENS Holiday Awards",
     "rules": {
       "awardModel": "pie-split",
-      "totalAwardPoolValue": { "currency": "USDC", "amount": "10000000000" },
+      "awardPool": { "currency": "USDC", "amount": "10000000000" },
       "maxQualifiedReferrers": 10,
       "startTime": 1764547200,
       "endTime": 1767225599,
@@ -20,10 +20,11 @@
     "slug": "2026-04",
     "displayName": "April 2026",
     "rules": {
-      "awardModel": "rev-share-limit",
-      "totalAwardPoolValue": { "currency": "USDC", "amount": "10000000000" },
-      "minQualifiedRevenueContribution": { "currency": "USDC", "amount": "100000000" },
-      "qualifiedRevenueShare": 0.5,
+      "awardModel": "rev-share-cap",
+      "awardPool": { "currency": "USDC", "amount": "10000000000" },
+      "minBaseRevenueContribution": { "currency": "USDC", "amount": "100000000" },
+      "baseAnnualRevenueContribution": { "currency": "USDC", "amount": "5000000" },
+      "maxBaseRevenueShare": 0.5,
       "startTime": 1775001600,
       "endTime": 1777593599,
       "subregistryId": {
@@ -32,10 +33,16 @@
       },
       "rulesUrl": "https://ensawards.org/ens-referral-program/editions/2026-04/rules",
       "areAwardsDistributed": false,
-      "disqualifications": [
+      "adminActions": [
         {
+          "actionType": "Disqualification",
           "referrer": "0x9a75ed8e1e592c2e2b0d3eddee8404dcf326a8c5",
           "reason": "Disqualified for April 2026 due to violation of rule 1 of the Code of Conduct. Insufficient evidence that most referrals were not self-referrals."
+        },
+        {
+          "actionType": "Warning",
+          "referrer": "0x02fa71cbb4b1b990a475deb370d0aa42aa43503b",
+          "reason": "A number of referrals for April 2026 are self-referrals. Continued self-referrals will violate rule 1 of the Code of Conduct and result in disqualification for April 2026."
         }
       ]
     }
@@ -44,10 +51,11 @@
     "slug": "2026-05",
     "displayName": "May 2026",
     "rules": {
-      "awardModel": "rev-share-limit",
-      "totalAwardPoolValue": { "currency": "USDC", "amount": "30000000000" },
-      "minQualifiedRevenueContribution": { "currency": "USDC", "amount": "100000000" },
-      "qualifiedRevenueShare": 0.5,
+      "awardModel": "rev-share-cap",
+      "awardPool": { "currency": "USDC", "amount": "30000000000" },
+      "minBaseRevenueContribution": { "currency": "USDC", "amount": "100000000" },
+      "baseAnnualRevenueContribution": { "currency": "USDC", "amount": "5000000" },
+      "maxBaseRevenueShare": 0.5,
       "startTime": 1777593600,
       "endTime": 1780271999,
       "subregistryId": {
@@ -56,7 +64,7 @@
       },
       "rulesUrl": "https://ensawards.org/ens-referral-program/editions/2026-05/rules",
       "areAwardsDistributed": false,
-      "disqualifications": []
+      "adminActions": []
     }
   }
 ]


### PR DESCRIPTION
# Lite PR &rarr; Adapt `production-editions.json` to ensnode v1.10.0

## Summary

- Copied the contents of **`ensawards.org\public\production-editions-v1.10.0.json`** into **`ensawards.org\public\production-editions.json`** bringing the latter up-to-date with the latest breaking changes of `v1.10.0` 

---

## Why

- Requested [here on Slack](https://namehash.slack.com/archives/C086Z6FNBHN/p1777479866141759)
- This will allow the correct work of ens-referrals-related endpoints in the `green` environment when we deploy our latest version there

---

## Testing

- There was no testing because the new `production-editions.json` is a 1:1 copy of the `ensawards.org\public\production-editions-v1.10.0.json`, which is confirmed to work on v1.10.1 deployment on blue. 
- Therefore, if both config files are identical, they should work the same way

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
