### PR TITLE
chore: Add new FAQ items for ENS Referral Program

### DIFF
--- a/ensawards.org/src/components/atoms/cards/FoldableCard.tsx
+++ b/ensawards.org/src/components/atoms/cards/FoldableCard.tsx
@@ -18,7 +18,8 @@ export function FoldableCard({
 }: PropsWithChildren<FoldableCardProps>) {
   const [isOpen, setIsOpen] = useState<boolean>(initiallyOpen);
   const [animationParent] = useAutoAnimate();
-  const chevronStyles = "text-black/30 hover:text-black/60";
+  const chevronStyles =
+    "text-black/30 hover:text-black/60 shrink-0 transition-transform duration-200";
   return (
     <div
       ref={animationParent}
@@ -29,7 +30,7 @@ export function FoldableCard({
         cardStyles,
       )}
     >
-      <div className="w-full h-fit flex flex-row flex-nowrap justify-between items-center">
+      <div className="w-full h-fit flex flex-row flex-nowrap justify-between items-start gap-3">
         <h4 className="text-lg leading-6 font-semibold text-black">{header}</h4>
         <ChevronRight size={24} className={cn(chevronStyles, isOpen && "rotate-90")} />
       </div>

--- a/ensawards.org/src/components/molecules/FrequentlyAskedQuestions.tsx
+++ b/ensawards.org/src/components/molecules/FrequentlyAskedQuestions.tsx
@@ -2,7 +2,22 @@ import type { ReactElement } from "react";
 
 import { FoldableCard } from "../atoms/cards/FoldableCard.tsx";
 
+export const faqIds = {
+  RefLinkLimitations: "referral-link-limitations",
+  EarningPoints: "earning-points",
+  ENSTokens: "ens-tokens",
+  RewardsToEarn: "rewards-to-earn",
+  SmartContractVsRefLink: "smart-contract-vs-referral-link",
+  OnchainRef: "onchain-referral",
+  RenewalsVsRegistrations: "renewals-vs-registrations",
+  ThresholdNotAchieved: "threshold-not-achieved",
+  IntegrationTime: "integration-time",
+} as const;
+
+export type FaqId = (typeof faqIds)[keyof typeof faqIds];
+
 export interface FrequentlyAskedQuestion {
+  id: FaqId;
   question: string;
   answer: ReactElement;
 }
@@ -13,6 +28,7 @@ const textStyles = "text-base leading-normal font-normal text-muted-foreground";
 
 const frequentlyAskedQuestions: FrequentlyAskedQuestion[] = [
   {
+    id: faqIds.RefLinkLimitations,
     question: "Are there limitations to the referral links?",
     answer: (
       <p className={textStyles}>
@@ -25,6 +41,7 @@ const frequentlyAskedQuestions: FrequentlyAskedQuestion[] = [
     ),
   },
   {
+    id: faqIds.EarningPoints,
     question: "How do I earn points?",
     answer: (
       <p className={textStyles}>
@@ -36,6 +53,7 @@ const frequentlyAskedQuestions: FrequentlyAskedQuestion[] = [
     ),
   },
   {
+    id: faqIds.ENSTokens,
     question: "What's an $ENS?",
     answer: (
       <p className={textStyles}>
@@ -79,10 +97,74 @@ const frequentlyAskedQuestions: FrequentlyAskedQuestion[] = [
       </p>
     ),
   },
+  {
+    id: faqIds.RewardsToEarn,
+    question: "How much I can earn?",
+    answer: (
+      <p className={textStyles}>
+        You earn up to a 50% revenue share on every .eth name registration and renewal attributed to
+        you. You must generate at least $100 in &quot;base revenue contribution&quot; within an
+        edition to qualify for awards. Awards are paid in USDC within 15 days of the edition
+        closing.
+      </p>
+    ),
+  },
+  {
+    id: faqIds.SmartContractVsRefLink,
+    question: "What's the difference between referral links and smart contract integration?",
+    answer: (
+      <p className={textStyles}>
+        Referral links direct users to the ENS Manager App with your attribution. They are easy to
+        set up, and allow you to launch within minutes. Smart contract integration lets you build
+        custom .eth registration and renewal flows directly into your app, giving you full UX
+        control. Both earn the same up to 50% revenue share.
+      </p>
+    ),
+  },
+  {
+    id: faqIds.OnchainRef,
+    question: "How does onchain referral attribution work?",
+    answer: (
+      <p className={textStyles}>
+        When your app calls the ENS registration or renewal contracts, you pass your referrer
+        address as a parameter. Attribution is recorded onchain and is indexed by our open source
+        rules engine that powers the ENSAwards referral leaderboards.
+      </p>
+    ),
+  },
+  {
+    id: faqIds.RenewalsVsRegistrations,
+    question: "Do renewals count the same as new registrations?",
+    answer: (
+      <p className={textStyles}>
+        Yes. Renewals generate the same referral revenue and awards as new registrations.
+      </p>
+    ),
+  },
+  {
+    id: faqIds.ThresholdNotAchieved,
+    question: "What happens if I don't hit the $100 threshold?",
+    answer: (
+      <p className={textStyles}>
+        You don't qualify for awards in that edition. But your referral activity is a strong signal,
+        use what you learned and apply it to the next edition.
+      </p>
+    ),
+  },
+  {
+    id: faqIds.IntegrationTime,
+    question: "How long does it take to integrate?",
+    answer: (
+      <p className={textStyles}>
+        A referral link takes no more than 30 seconds to generate. A smart contract integration can
+        be as simple as a 1-line code change to an existing registration or renewal flow.
+      </p>
+    ),
+  },
 ];
 
 export interface FrequentlyAskedQuestionsProps {
-  itemsToShow: string[];
+  itemsToShow: FaqId[];
   initiallyOpenItem?: number;
 }
 export function FrequentlyAskedQuestions({
@@ -92,7 +174,7 @@ export function FrequentlyAskedQuestions({
   return (
     <div className="w-full min-[810px]:w-1/2 min-[810px]:min-w-1/2 h-fit flex flex-col justify-start items-start gap-2">
       {frequentlyAskedQuestions
-        .filter((faq) => itemsToShow.includes(faq.question))
+        .filter((faq) => itemsToShow.includes(faq.id))
         .map((faq, idx) => (
           <FoldableCard
             key={`FAQ-#${idx}`}

--- a/ensawards.org/src/components/molecules/FrequentlyAskedQuestions.tsx
+++ b/ensawards.org/src/components/molecules/FrequentlyAskedQuestions.tsx
@@ -99,7 +99,7 @@ const frequentlyAskedQuestions: FrequentlyAskedQuestion[] = [
   },
   {
     id: faqIds.RewardsToEarn,
-    question: "How much I can earn?",
+    question: "How much can I earn?",
     answer: (
       <p className={textStyles}>
         You earn up to a 50% revenue share on every .eth name registration and renewal attributed to
@@ -146,8 +146,8 @@ const frequentlyAskedQuestions: FrequentlyAskedQuestion[] = [
     question: "What happens if I don't hit the $100 threshold?",
     answer: (
       <p className={textStyles}>
-        You don't qualify for awards in that edition. But your referral activity is a strong signal,
-        use what you learned and apply it to the next edition.
+        You don't qualify for awards in that edition. But your referral activity is a strong signal.
+        Use what you learned and apply it to the next edition.
       </p>
     ),
   },

--- a/ensawards.org/src/pages/ens-contract-naming-season/index.astro
+++ b/ensawards.org/src/pages/ens-contract-naming-season/index.astro
@@ -21,7 +21,7 @@ import { EnscribeSolidIcon } from "@/components/atoms/icons/EnscribeSolidIcon";
 import ContractNamingBestPractices from "@/components/contract-naming-season/ContractNamingBestPractices.astro";
 import ContractNamingHero from "@/components/contract-naming-season/ContractNamingHero.astro";
 import ContractNamingIncentivesBanner from "@/components/contract-naming-season/ContractNamingIncentivesBanner.astro";
-import { FrequentlyAskedQuestions } from "@/components/molecules/FrequentlyAskedQuestions";
+import { faqIds, FrequentlyAskedQuestions } from "@/components/molecules/FrequentlyAskedQuestions";
 import { shadcnButtonVariants } from "@/components/ui/shadcnButtonStyles";
 import Layout from "@/layouts/Layout.astro";
 import { type ProtocolId, ProtocolTypes } from "data/protocols/types.ts";
@@ -471,7 +471,7 @@ const startContractNamingTodayButtonStyles =
         </div>
         <FrequentlyAskedQuestions
           client:load
-          itemsToShow={["What's an $ENS?"]}
+          itemsToShow={[faqIds.ENSTokens]}
         />
       </div>
     </div>

--- a/ensawards.org/src/pages/ens-referral-program/index.astro
+++ b/ensawards.org/src/pages/ens-referral-program/index.astro
@@ -17,6 +17,7 @@ import { LiveReferralFeed } from "@/components/referral-awards-program/referrals
 import { shadcnButtonVariants } from "@/components/ui/shadcnButtonStyles";
 import { cn } from "@/utils/tailwindClassConcatenation";
 import Layout from "@/layouts/Layout.astro";
+import { faqIds } from "@/components/molecules/FrequentlyAskedQuestions";
 
 interface ContentItemData {
   name: string;
@@ -336,7 +337,15 @@ const backgroundGreyStyles =
         </div>
         <FrequentlyAskedQuestions
           client:load
-          itemsToShow={["Are there limitations to the referral links?"]}
+          itemsToShow={[
+            faqIds.RefLinkLimitations,
+            faqIds.RewardsToEarn,
+            faqIds.SmartContractVsRefLink,
+            faqIds.OnchainRef,
+            faqIds.RenewalsVsRegistrations,
+            faqIds.ThresholdNotAchieved,
+            faqIds.IntegrationTime,
+          ]}
         />
       </div>
     </div>

--- a/ensawards.org/src/pages/ens-referral-program/index.astro
+++ b/ensawards.org/src/pages/ens-referral-program/index.astro
@@ -8,7 +8,7 @@ import {
   Sparkles,
   TrendingUp,
 } from "@lucide/astro";
-import { FrequentlyAskedQuestions } from "@/components/molecules/FrequentlyAskedQuestions";
+import { FrequentlyAskedQuestions, faqIds } from "@/components/molecules/FrequentlyAskedQuestions";
 import JoinTelegram from "@/components/molecules/JoinTelegram.astro";
 import { ReferralProgramEditionsList } from "@/components/molecules/ReferralProgramEditionsList";
 import { ReferralLinkForm } from "@/components/referral-awards-program/ReferralLinkForm";
@@ -17,7 +17,6 @@ import { LiveReferralFeed } from "@/components/referral-awards-program/referrals
 import { shadcnButtonVariants } from "@/components/ui/shadcnButtonStyles";
 import { cn } from "@/utils/tailwindClassConcatenation";
 import Layout from "@/layouts/Layout.astro";
-import { faqIds } from "@/components/molecules/FrequentlyAskedQuestions";
 
 interface ContentItemData {
   name: string;


### PR DESCRIPTION
# Lite PR &rarr; Add new FAQ items for ENS Referral Program

## Summary

- Added new FAQ items to **`ensawards.org/src/components/molecules/FrequentlyAskedQuestions.tsx`** from the [Google Doc spec](https://docs.google.com/document/d/1lxTsp9FPzeDg_LjQA819LSnW8GEZP0ylTwI7FLMowEY/edit?usp=sharing) provided by @caldonia-eth 
- Refined the faq selection logic by adding enum-like IDs for each question

---

## Why

- Requested by @lightwalker-eth [here](https://namehash.slack.com/archives/C086Z6FNBHN/p1775735034462179)

---

## Testing

- Ran `typecheck`, `lint`, and `test` commands locally to ensure that the migration didn't break anything, and later confirmed that in our CI workflow
- Verified that the UI didn't break/change using a local and Vercel preview (and fixed spotted display errors)

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
