### PR TITLE
chore: Hide empty "Scheduled" section of referral program editions

### DIFF
--- a/ensawards.org/src/components/molecules/ReferralProgramEditionsList.tsx
+++ b/ensawards.org/src/components/molecules/ReferralProgramEditionsList.tsx
@@ -116,7 +116,11 @@ const ReferralProgramEditionsListContainer = ({
           />
         )}
       </div>
-      <div className={subcontainerStyles}>
+      {/* Temporarily hide the section when it's empty 
+      to avoid giving the impression that no referral program editions will come after the current one in May.
+      When the next edition is added to production-editions.json we should be able to just rollback the hiding logic.
+      For more details see: https://namehash.slack.com/archives/C086Z6FNBHN/p1778064151996799 */}
+      <div className={cn(subcontainerStyles, scheduledEditions.length === 0 && "hidden")}>
         <h2 className={headerStyles}>Scheduled</h2>
         {scheduledEditions.length > 0 ? (
           <div className={editionsListStyles}>{scheduledEditions}</div>
@@ -254,25 +258,28 @@ const DisplayGroupedReferralProgramEditionSummariesList = ({
                 />
               );
             })}
-          scheduledEditions={loadingReferralProgramEditionSummaries
-            .filter(
-              (editionSummary) =>
-                editionSummary.status === ReferralProgramEditionStatuses.Scheduled,
-            )
-            .map((editionSummary, index) => {
-              if (editionSummary.awardModel === ReferralProgramAwardModels.RevShareCap) {
-                return (
-                  <ReferralProgramEditionCardRevShareCapLoading
-                    key={`referral-program-edition-loading-scheduled#${index}`}
-                  />
-                );
-              }
-              return (
-                <ReferralProgramEditionCardPieSplitLoading
-                  key={`referral-program-edition-loading-scheduled#${index}`}
-                />
-              );
-            })}
+          // scheduledEditions={loadingReferralProgramEditionSummaries
+          //   .filter(
+          //     (editionSummary) =>
+          //       editionSummary.status === ReferralProgramEditionStatuses.Scheduled,
+          //   )
+          //   .map((editionSummary, index) => {
+          //     if (editionSummary.awardModel === ReferralProgramAwardModels.RevShareCap) {
+          //       return (
+          //         <ReferralProgramEditionCardRevShareCapLoading
+          //           key={`referral-program-edition-loading-scheduled#${index}`}
+          //         />
+          //       );
+          //     }
+          //     return (
+          //       <ReferralProgramEditionCardPieSplitLoading
+          //         key={`referral-program-edition-loading-scheduled#${index}`}
+          //       />
+          //     );
+          //   })}
+          // TODO: Temporarily commented out and passing an empty array.
+          // See L119 for more details.
+          scheduledEditions={[]}
         />
       )}
       {!isLoading && referralProgramEditionSummaries === null && (

--- a/ensawards.org/src/pages/ens-referral-program/editions/index.astro
+++ b/ensawards.org/src/pages/ens-referral-program/editions/index.astro
@@ -5,13 +5,19 @@ import SubpageHero from "../../../components/molecules/SubpageHero.astro";
 import { ReferralProgramEditionsList } from "../../../components/molecules/ReferralProgramEditionsList";
 import { cn } from "../../../utils/tailwindClassConcatenation";
 import { shadcnButtonVariants } from "../../../components/ui/shadcnButtonStyles";
+
+// Temporarily change the wording of the description
+// to avoid giving the impression that no referral program editions will come after the current one in May.
+// When the next edition is added to production-editions.json we should be able to just rollback to the previous text.
+// For more details see: https://namehash.slack.com/archives/C086Z6FNBHN/p1778064151996799
 ---
 
 <Layout
   pageMetadata={{
     title: "ENSAwards: ENS Referral Program Editions",
-    description:
-      "Explore editions that are currently active, scheduled for the future, or already closed.",
+    // description:
+    //   "Explore editions that are currently active, scheduled for the future, or already closed.",
+    description: "Explore all editions.",
     url: "https://ensawards.org/ens-referral-program/editions",
     ogImage: "https://ensawards.org/ens_referral_program_editions_og_image.png",
     twitterImage:
@@ -19,7 +25,7 @@ import { shadcnButtonVariants } from "../../../components/ui/shadcnButtonStyles"
   }}>
   <SubpageHero
     header="ENS referral program editions"
-    description="Explore editions that are currently active, scheduled for the future, or already closed."
+    description="Explore all editions."
     breadcrumbs={[
       { text: "ENS Referral Program", linkHref: "/ens-referral-program" },
     ]}

--- a/ensawards.org/src/pages/ens-referral-program/index.astro
+++ b/ensawards.org/src/pages/ens-referral-program/index.astro
@@ -113,8 +113,13 @@ const backgroundGreyStyles =
           ENS referral program editions
         </h3>
         <p class={cn(descriptionStyles, "text-center")}>
-          Explore editions that are currently active, scheduled for the future,
-          or already closed.
+          <!-- Explore editions that are currently active, scheduled for the future,
+          or already closed. -->
+          <!-- Temporarily change the wording of the description 
+      to avoid giving the impression that no referral program editions will come after the current one in May.
+      When the next edition is added to production-editions.json we should be able to just rollback to the previous text.
+      For more details see: https://namehash.slack.com/archives/C086Z6FNBHN/p1778064151996799  -->
+          Explore all editions.
         </p>
       </div>
       <ReferralProgramEditionsList client:load />


### PR DESCRIPTION
# Lite PR &rarr; Hide empty "Scheduled" section of referral program editions

## Summary

- Slightly altered the logic in **`ensawards.org/src/components/molecules/ReferralProgramEditionsList.tsx`** to hide the `Scheduled` section of the list when it's empty (like now). 
- When the next edition is added to `production-editions.json`, we should be able to roll back the hiding logic.

---

## Why

- We should hide any statements explicitly suggesting that there is no new referral program edition coming after the current one
- Requested [here](https://namehash.slack.com/archives/C086Z6FNBHN/p1778064151996799) by @lightwalker-eth 

---

## Testing

- Ran `typecheck`, `lint`, and `test` commands locally to ensure that the migration didn't break anything, and later confirmed that in our CI workflow
- Verified that the UI didn't break/change using a local and Vercel preview

---

## Notes for Reviewer (Optional)

- We can also solve this issue by changing the empty section text to something like `"We're actively working on a new edition that will be announced soon"`
    - I didn't go with that because I felt like it still emphasizes the lack of planned editions in the strict sense of it, making us look unprofessional
    - That being said, I am willing to use that solution if it's preferable

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
