### PR TITLE
chore: Refine UI/UX of generalized benchmark result display

### DIFF
--- a/ensawards.org/data/benchmarks/types.ts
+++ b/ensawards.org/data/benchmarks/types.ts
@@ -28,26 +28,27 @@ export type AcceptanceTestBenchmarks = Record<
 >;
 
 /**
- * Represents the ratio of successful benchmarks
+ * Represents the ratio of failed benchmarks
  * for a given {@link App}, {@link BestPractice}, or {@link BestPracticeCategory}.
  */
-export interface BenchmarkSuccessRatio {
+export interface BenchmarkFailRatio {
   /**
    * Number of all tests that
-   * had a benchmark result of `BenchmarkResults.Pass` or `BenchmarkResults.PartialPass`
-   * for the given {@link App}, {@link BestPractice}, or {@link BestPracticeCategory}.
+   * had a benchmark result of `BenchmarkResults.Fail` for the given {@link App}, {@link BestPractice}, or {@link BestPracticeCategory}.
    *
    * @invariant
    * Must be >= 0
    */
-  testsPassed: number;
+  benchmarksFailed: number;
 
   /**
-   * Number of all tests that were relevant
+   * Number of all test benchmarks that were relevant
    * for the given {@link App}, {@link BestPractice}, or {@link BestPracticeCategory}.
    *
+   * Includes `pending` and `not-applicable` benchmarks.
+   *
    * @invariant
-   * Must be greater or equal to `testsPassed`.
+   * Must be greater or equal to `benchmarksFailed`.
    */
-  allTests: number;
+  allBenchmarks: number;
 }

--- a/ensawards.org/data/benchmarks/types.ts
+++ b/ensawards.org/data/benchmarks/types.ts
@@ -26,3 +26,28 @@ export type AcceptanceTestBenchmarks = Record<
   AcceptanceTestSlug,
   AcceptanceTestBenchmark | undefined
 >;
+
+/**
+ * Represents the ratio of successful benchmarks
+ * for a given {@link App}, {@link BestPractice}, or {@link BestPracticeCategory}.
+ */
+export interface BenchmarkSuccessRatio {
+  /**
+   * Number of all tests that
+   * had a benchmark result of `BenchmarkResults.Pass` or `BenchmarkResults.PartialPass`
+   * for the given {@link App}, {@link BestPractice}, or {@link BestPracticeCategory}.
+   *
+   * @invariant
+   * Must be >= 0
+   */
+  testsPassed: number;
+
+  /**
+   * Number of all tests that were relevant
+   * for the given {@link App}, {@link BestPractice}, or {@link BestPracticeCategory}.
+   *
+   * @invariant
+   * Must be greater or equal to `testsPassed`.
+   */
+  allTests: number;
+}

--- a/ensawards.org/data/benchmarks/types.ts
+++ b/ensawards.org/data/benchmarks/types.ts
@@ -48,7 +48,9 @@ export interface BenchmarkFailRatio {
    * Includes `pending` and `not-applicable` benchmarks.
    *
    * @invariant
-   * Must be greater or equal to `benchmarksFailed`.
+   * Must be >= `benchmarksFailed` and >= 1.
+   * Supported by the invariant of {@link AcceptanceTestBenchmarks}
+   * and type definition of {@link BestPractice.technicalDetails.acceptanceTests}.
    */
   allBenchmarks: number;
 }

--- a/ensawards.org/data/benchmarks/utils.test.ts
+++ b/ensawards.org/data/benchmarks/utils.test.ts
@@ -1,10 +1,12 @@
 import type { AcceptanceTestBenchmarkApplicable } from "data/acceptance-tests/types.ts";
 import {
+  calcBenchmarkSuccessRatio,
   calcBestPracticeCategoryScore,
   calcEnsAwardsPoints,
   groupBenchmarksByCategory,
   sortAcceptanceTestBenchmarks,
   sortBenchmarkResults,
+  sortBenchmarkSuccessRatios,
 } from "data/benchmarks/utils.ts";
 import type { BestPracticeBenchmarks, BestPracticeSlug } from "data/ens-best-practices/types.ts";
 import {
@@ -21,7 +23,11 @@ import {
 } from "data/shared/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { BenchmarkResults } from "./types.ts";
+import {
+  type AcceptanceTestBenchmarks,
+  BenchmarkResults,
+  type BenchmarkSuccessRatio,
+} from "./types.ts";
 
 const { mockGetBestPracticeBySlug } = vi.hoisted(() => ({
   mockGetBestPracticeBySlug: vi.fn(),
@@ -354,6 +360,78 @@ describe("benchmarks-utils", () => {
 
       expectedOutput.forEach((benchmark, index) =>
         expect(benchmark, `Expected sorted benchmark at index ${index} to match`).toEqual(
+          result[index],
+        ),
+      );
+    });
+  });
+
+  describe("calcBenchmarkSuccessRatio", () => {
+    it("should return the correct success ratio for a given set of benchmarks", () => {
+      const expectedResult = {
+        testsPassed: 3,
+        allTests: 5,
+      } as const satisfies BenchmarkSuccessRatio;
+
+      const inputBenchmarks = {
+        "mock-acceptance-test-1": createMockAcceptanceTestBenchmark(BenchmarkResults.Pass),
+        "mock-acceptance-test-2": createMockAcceptanceTestBenchmark(BenchmarkResults.Pass),
+        "mock-acceptance-test-3": createMockAcceptanceTestBenchmark(BenchmarkResults.NotApplicable),
+        // benchmarks with `not-applicable` result should be ignored
+        "mock-acceptance-test-4": undefined,
+        // pending benchmarks should be ignored
+        "mock-acceptance-test-5": createMockAcceptanceTestBenchmark(BenchmarkResults.Fail),
+        "mock-acceptance-test-6": createMockAcceptanceTestBenchmark(BenchmarkResults.PartialPass),
+        "mock-acceptance-test-7": createMockAcceptanceTestBenchmark(BenchmarkResults.Fail),
+      } as const satisfies AcceptanceTestBenchmarks;
+
+      const result = calcBenchmarkSuccessRatio(inputBenchmarks);
+
+      expect(
+        result,
+        "Expected calcBenchmarkSuccessRatio to return the correct success ratio for a given set of benchmarks",
+      ).toEqual(expectedResult);
+    });
+
+    it("should return undefined if there are no applicable benchmarks", () => {
+      const inputBenchmarks = {
+        "mock-acceptance-test-1": undefined,
+        "mock-acceptance-test-2": undefined,
+        "mock-acceptance-test-3": createMockAcceptanceTestBenchmark(BenchmarkResults.NotApplicable),
+        "mock-acceptance-test-4": undefined,
+      } as const satisfies AcceptanceTestBenchmarks;
+
+      const result = calcBenchmarkSuccessRatio(inputBenchmarks);
+
+      expect(
+        result,
+        "Expected result to be undefined when there are only pending or not applicable benchmarks",
+      ).toBeUndefined();
+    });
+  });
+
+  describe("sortBenchmarkSuccessRatios", () => {
+    it("should allow correct sorting of benchmark success ratios", () => {
+      const input = [
+        undefined,
+        { testsPassed: 2, allTests: 10 },
+        { testsPassed: 3, allTests: 4 },
+        { testsPassed: 2, allTests: 5 },
+        { testsPassed: 0, allTests: 2 },
+      ];
+
+      const expectedOutput = [
+        { testsPassed: 3, allTests: 4 }, // 75%
+        { testsPassed: 2, allTests: 5 }, // 40%
+        { testsPassed: 2, allTests: 10 }, // 20%
+        { testsPassed: 0, allTests: 2 }, // 0%
+        undefined, // all benchmarks either pending or not applicable
+      ];
+
+      const result = input.sort((a, b) => sortBenchmarkSuccessRatios(a, b));
+
+      expectedOutput.forEach((successRatio, index) =>
+        expect(successRatio, `Expected sorted success ratio at index ${index} to match`).toEqual(
           result[index],
         ),
       );

--- a/ensawards.org/data/benchmarks/utils.test.ts
+++ b/ensawards.org/data/benchmarks/utils.test.ts
@@ -1,12 +1,12 @@
 import type { AcceptanceTestBenchmarkApplicable } from "data/acceptance-tests/types.ts";
 import {
-  calcBenchmarkSuccessRatio,
+  calcBenchmarkFailRatio,
   calcBestPracticeCategoryScore,
   calcEnsAwardsPoints,
   groupBenchmarksByCategory,
   sortAcceptanceTestBenchmarks,
+  sortBenchmarkFailRatios,
   sortBenchmarkResults,
-  sortBenchmarkSuccessRatios,
 } from "data/benchmarks/utils.ts";
 import type { BestPracticeBenchmarks, BestPracticeSlug } from "data/ens-best-practices/types.ts";
 import {
@@ -25,8 +25,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   type AcceptanceTestBenchmarks,
+  type BenchmarkFailRatio,
   BenchmarkResults,
-  type BenchmarkSuccessRatio,
 } from "./types.ts";
 
 const { mockGetBestPracticeBySlug } = vi.hoisted(() => ({
@@ -366,72 +366,52 @@ describe("benchmarks-utils", () => {
     });
   });
 
-  describe("calcBenchmarkSuccessRatio", () => {
-    it("should return the correct success ratio for a given set of benchmarks", () => {
+  describe("calcBenchmarkFailRatio", () => {
+    it("should return the correct fail ratio for a given set of benchmarks", () => {
       const expectedResult = {
-        testsPassed: 3,
-        allTests: 5,
-      } as const satisfies BenchmarkSuccessRatio;
+        benchmarksFailed: 2,
+        allBenchmarks: 7,
+      } as const satisfies BenchmarkFailRatio;
 
       const inputBenchmarks = {
         "mock-acceptance-test-1": createMockAcceptanceTestBenchmark(BenchmarkResults.Pass),
         "mock-acceptance-test-2": createMockAcceptanceTestBenchmark(BenchmarkResults.Pass),
         "mock-acceptance-test-3": createMockAcceptanceTestBenchmark(BenchmarkResults.NotApplicable),
-        // benchmarks with `not-applicable` result should be ignored
         "mock-acceptance-test-4": undefined,
-        // pending benchmarks should be ignored
         "mock-acceptance-test-5": createMockAcceptanceTestBenchmark(BenchmarkResults.Fail),
         "mock-acceptance-test-6": createMockAcceptanceTestBenchmark(BenchmarkResults.PartialPass),
         "mock-acceptance-test-7": createMockAcceptanceTestBenchmark(BenchmarkResults.Fail),
       } as const satisfies AcceptanceTestBenchmarks;
 
-      const result = calcBenchmarkSuccessRatio(inputBenchmarks);
+      const result = calcBenchmarkFailRatio(inputBenchmarks);
 
       expect(
         result,
-        "Expected calcBenchmarkSuccessRatio to return the correct success ratio for a given set of benchmarks",
+        "Expected calcBenchmarkFailRatio to return the correct fail ratio for a given set of benchmarks",
       ).toEqual(expectedResult);
-    });
-
-    it("should return undefined if there are no applicable benchmarks", () => {
-      const inputBenchmarks = {
-        "mock-acceptance-test-1": undefined,
-        "mock-acceptance-test-2": undefined,
-        "mock-acceptance-test-3": createMockAcceptanceTestBenchmark(BenchmarkResults.NotApplicable),
-        "mock-acceptance-test-4": undefined,
-      } as const satisfies AcceptanceTestBenchmarks;
-
-      const result = calcBenchmarkSuccessRatio(inputBenchmarks);
-
-      expect(
-        result,
-        "Expected result to be undefined when there are only pending or not applicable benchmarks",
-      ).toBeUndefined();
     });
   });
 
-  describe("sortBenchmarkSuccessRatios", () => {
-    it("should allow correct sorting of benchmark success ratios", () => {
+  describe("sortBenchmarkFailRatios", () => {
+    it("should allow correct sorting of benchmark fail ratios", () => {
       const input = [
-        undefined,
-        { testsPassed: 2, allTests: 10 },
-        { testsPassed: 3, allTests: 4 },
-        { testsPassed: 2, allTests: 5 },
-        { testsPassed: 0, allTests: 2 },
+        { benchmarksFailed: 2, allBenchmarks: 10 },
+        { benchmarksFailed: 1, allBenchmarks: 4 },
+        { benchmarksFailed: 3, allBenchmarks: 5 },
+        { benchmarksFailed: 2, allBenchmarks: 2 },
       ];
 
       const expectedOutput = [
-        { testsPassed: 3, allTests: 4 }, // 75%
-        { testsPassed: 2, allTests: 5 }, // 40%
-        { testsPassed: 2, allTests: 10 }, // 20%
-        { testsPassed: 0, allTests: 2 }, // 0%
-        undefined, // all benchmarks either pending or not applicable
+        { benchmarksFailed: 2, allBenchmarks: 10 }, // 20%
+        { benchmarksFailed: 1, allBenchmarks: 4 }, // 25%
+        { benchmarksFailed: 3, allBenchmarks: 5 }, // 60%
+        { benchmarksFailed: 2, allBenchmarks: 2 }, // 100%
       ];
 
-      const result = input.sort((a, b) => sortBenchmarkSuccessRatios(a, b));
+      const result = input.sort((a, b) => sortBenchmarkFailRatios(a, b));
 
-      expectedOutput.forEach((successRatio, index) =>
-        expect(successRatio, `Expected sorted success ratio at index ${index} to match`).toEqual(
+      expectedOutput.forEach((failRatio, index) =>
+        expect(failRatio, `Expected sorted fail ratio at index ${index} to match`).toEqual(
           result[index],
         ),
       );

--- a/ensawards.org/data/benchmarks/utils.ts
+++ b/ensawards.org/data/benchmarks/utils.ts
@@ -8,7 +8,6 @@ import { getAppBySlug } from "data/apps/utils.ts";
 import { getBestPracticeBySlug } from "data/ens-best-practices/utils.ts";
 import type { FormatTypeOptions } from "data/shared/format-type-options.ts";
 import type { UnixTimestamp } from "enssdk";
-import { bench } from "vitest";
 
 import type {
   BestPractice,
@@ -389,6 +388,12 @@ export const calcBenchmarkFailRatio = (
  * Sort order: ascending by the ratio of failed benchmarks to all benchmarks.
  */
 export const sortBenchmarkFailRatios = (a: BenchmarkFailRatio, b: BenchmarkFailRatio): number => {
+  if (a.allBenchmarks === 0 || b.allBenchmarks === 0) {
+    throw new Error(
+      `Invariant(BenchmarkFailRatio): allBenchmarks must be greater than 0 for both ratios being compared`,
+    );
+  }
+
   const aNumericalFailRatio = a.benchmarksFailed / a.allBenchmarks;
   const bNumericalFailRatio = b.benchmarksFailed / b.allBenchmarks;
 

--- a/ensawards.org/data/benchmarks/utils.ts
+++ b/ensawards.org/data/benchmarks/utils.ts
@@ -8,6 +8,7 @@ import { getAppBySlug } from "data/apps/utils.ts";
 import { getBestPracticeBySlug } from "data/ens-best-practices/utils.ts";
 import type { FormatTypeOptions } from "data/shared/format-type-options.ts";
 import type { UnixTimestamp } from "enssdk";
+import { bench } from "vitest";
 
 import type {
   BestPractice,
@@ -31,9 +32,9 @@ import {
 import { APP_BENCHMARKS } from ".";
 import {
   type AcceptanceTestBenchmarks,
+  type BenchmarkFailRatio,
   type BenchmarkResult,
   BenchmarkResults,
-  type BenchmarkSuccessRatio,
 } from "./types.ts";
 
 /** Returns all benchmarks of an {@link App} by its {@link AppSlug}.
@@ -361,53 +362,35 @@ export const summarizeAppsAcceptanceTestBenchmarks = (
 };
 
 /**
- * Calculates the {@link BenchmarkSuccessRatio} for a given set of {@link AcceptanceTestBenchmarks}.
+ * Calculates the {@link BenchmarkFailRatio} for a given set of {@link AcceptanceTestBenchmarks}.
  *
- * Omits the `undefined` (pending) benchmarks and the ones with `BenchmarkResults.NotApplicable` from the calculation.
+ * Includes the `undefined` (pending) benchmarks and the ones with `BenchmarkResults.NotApplicable`
+ * in the calculation of `allBenchmarks`.
  */
-export const calcBenchmarkSuccessRatio = (
+export const calcBenchmarkFailRatio = (
   acceptanceTestBenchmarks: AcceptanceTestBenchmarks,
-): BenchmarkSuccessRatio | undefined => {
-  let testsPassed = 0;
-  let allTests = 0;
+): BenchmarkFailRatio => {
+  const benchmarks = Object.values(acceptanceTestBenchmarks);
+  let benchmarksFailed = 0;
+  const allBenchmarks = benchmarks.length;
 
-  for (const benchmark of Object.values(acceptanceTestBenchmarks)) {
-    if (benchmark === undefined || benchmark.result === BenchmarkResults.NotApplicable) {
-      continue;
+  benchmarks.forEach((benchmark) => {
+    if (benchmark && benchmark.result === BenchmarkResults.Fail) {
+      benchmarksFailed += 1;
     }
+  });
 
-    allTests += 1;
-
-    // Currently, we treat `BenchmarkResults.PartialPass`
-    // and `BenchmarkResults.Pass` as successful benchmarks.
-    if (
-      benchmark.result === BenchmarkResults.Pass ||
-      benchmark.result === BenchmarkResults.PartialPass
-    ) {
-      testsPassed += 1;
-    }
-  }
-
-  if (allTests === 0) {
-    return undefined;
-  }
-
-  return { testsPassed, allTests };
+  return { benchmarksFailed, allBenchmarks };
 };
 
 /**
- * Sorts two {@link BenchmarkSuccessRatio}s relative to each other.
+ * Sorts two {@link BenchmarkFailRatio}s relative to each other.
+ *
+ * Sort order: ascending by the ratio of failed benchmarks to all benchmarks.
  */
-export const sortBenchmarkSuccessRatios = (
-  a: BenchmarkSuccessRatio | undefined,
-  b: BenchmarkSuccessRatio | undefined,
-): number => {
-  if (a === undefined && b === undefined) return 0;
-  if (a === undefined) return 1;
-  if (b === undefined) return -1;
+export const sortBenchmarkFailRatios = (a: BenchmarkFailRatio, b: BenchmarkFailRatio): number => {
+  const aNumericalFailRatio = a.benchmarksFailed / a.allBenchmarks;
+  const bNumericalFailRatio = b.benchmarksFailed / b.allBenchmarks;
 
-  const aNumericalSuccesRatio = a.testsPassed / a.allTests;
-  const bNumericalSuccesRatio = b.testsPassed / b.allTests;
-
-  return bNumericalSuccesRatio - aNumericalSuccesRatio;
+  return aNumericalFailRatio - bNumericalFailRatio;
 };

--- a/ensawards.org/data/benchmarks/utils.ts
+++ b/ensawards.org/data/benchmarks/utils.ts
@@ -402,14 +402,12 @@ export const sortBenchmarkSuccessRatios = (
   a: BenchmarkSuccessRatio | undefined,
   b: BenchmarkSuccessRatio | undefined,
 ): number => {
-  let successRatioDiff = 0;
-  if (a !== undefined && b !== undefined) {
-    const aNumericalSuccesRatio = a.testsPassed / a.allTests;
-    const bNumericalSuccesRatio = b.testsPassed / b.allTests;
+  if (a === undefined && b === undefined) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
 
-    successRatioDiff = bNumericalSuccesRatio - aNumericalSuccesRatio;
-  }
-  if (a === undefined) successRatioDiff = 1;
-  if (b === undefined) successRatioDiff = -1;
-  return successRatioDiff;
+  const aNumericalSuccesRatio = a.testsPassed / a.allTests;
+  const bNumericalSuccesRatio = b.testsPassed / b.allTests;
+
+  return bNumericalSuccesRatio - aNumericalSuccesRatio;
 };

--- a/ensawards.org/data/benchmarks/utils.ts
+++ b/ensawards.org/data/benchmarks/utils.ts
@@ -29,7 +29,12 @@ import {
   EnsAwardsUndefinedScoreLabels,
 } from "../shared/ens-awards-score.ts";
 import { APP_BENCHMARKS } from ".";
-import { type AcceptanceTestBenchmarks, type BenchmarkResult, BenchmarkResults } from "./types.ts";
+import {
+  type AcceptanceTestBenchmarks,
+  type BenchmarkResult,
+  BenchmarkResults,
+  type BenchmarkSuccessRatio,
+} from "./types.ts";
 
 /** Returns all benchmarks of an {@link App} by its {@link AppSlug}.
  */
@@ -353,4 +358,58 @@ export const summarizeAppsAcceptanceTestBenchmarks = (
     bestPractice,
     generalizedBenchmarkResult,
   };
+};
+
+/**
+ * Calculates the {@link BenchmarkSuccessRatio} for a given set of {@link AcceptanceTestBenchmarks}.
+ *
+ * Omits the `undefined` (pending) benchmarks and the ones with `BenchmarkResults.NotApplicable` from the calculation.
+ */
+export const calcBenchmarkSuccessRatio = (
+  acceptanceTestBenchmarks: AcceptanceTestBenchmarks,
+): BenchmarkSuccessRatio | undefined => {
+  let testsPassed = 0;
+  let allTests = 0;
+
+  for (const benchmark of Object.values(acceptanceTestBenchmarks)) {
+    if (benchmark === undefined || benchmark.result === BenchmarkResults.NotApplicable) {
+      continue;
+    }
+
+    allTests += 1;
+
+    // Currently, we treat `BenchmarkResults.PartialPass`
+    // and `BenchmarkResults.Pass` as successful benchmarks.
+    if (
+      benchmark.result === BenchmarkResults.Pass ||
+      benchmark.result === BenchmarkResults.PartialPass
+    ) {
+      testsPassed += 1;
+    }
+  }
+
+  if (allTests === 0) {
+    return undefined;
+  }
+
+  return { testsPassed, allTests };
+};
+
+/**
+ * Sorts two {@link BenchmarkSuccessRatio}s relative to each other.
+ */
+export const sortBenchmarkSuccessRatios = (
+  a: BenchmarkSuccessRatio | undefined,
+  b: BenchmarkSuccessRatio | undefined,
+): number => {
+  let successRatioDiff = 0;
+  if (a !== undefined && b !== undefined) {
+    const aNumericalSuccesRatio = a.testsPassed / a.allTests;
+    const bNumericalSuccesRatio = b.testsPassed / b.allTests;
+
+    successRatioDiff = bNumericalSuccesRatio - aNumericalSuccesRatio;
+  }
+  if (a === undefined) successRatioDiff = 1;
+  if (b === undefined) successRatioDiff = -1;
+  return successRatioDiff;
 };

--- a/ensawards.org/src/components/atoms/badges/BenchmarkResultBadge.tsx
+++ b/ensawards.org/src/components/atoms/badges/BenchmarkResultBadge.tsx
@@ -43,6 +43,8 @@ const AlertIcon = ({ className, ...props }: React.SVGProps<SVGSVGElement>) => (
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    focusable="false"
     className={className}
     {...props}
   >
@@ -62,6 +64,8 @@ const PassIcon = ({ className, ...props }: React.SVGProps<SVGSVGElement>) => (
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    focusable="false"
     className={className}
     {...props}
   >

--- a/ensawards.org/src/components/atoms/badges/BenchmarkResultBadge.tsx
+++ b/ensawards.org/src/components/atoms/badges/BenchmarkResultBadge.tsx
@@ -1,17 +1,16 @@
-import { type BenchmarkResult, BenchmarkResults } from "data/benchmarks/types.ts";
-import { formatBenchmarkResult } from "data/benchmarks/utils.ts";
 import {
-  X as FailIcon,
-  CircleOff as NotApplicableIcon,
-  Check as PartialPassIcon,
-  CheckCheck as PassIcon,
-  Clock as PendingIcon,
-} from "lucide-react";
+  type BenchmarkResult,
+  BenchmarkResults,
+  type BenchmarkSuccessRatio,
+} from "data/benchmarks/types.ts";
+import { formatBenchmarkResult } from "data/benchmarks/utils.ts";
+import { CircleOff as NotApplicableIcon, Clock as PendingIcon } from "lucide-react";
 
 import { cn } from "@/utils/tailwindClassConcatenation";
 
 export interface BenchmarkResultBadgeProps {
   benchmarkResult?: BenchmarkResult;
+  successRatio?: BenchmarkSuccessRatio;
   className?: string;
 }
 
@@ -36,6 +35,45 @@ export const benchmarkResultToBadgeStyles = (benchmarkResult?: BenchmarkResult) 
   }
 };
 
+// These icons are unique to the benchmark result display.
+const AlertIcon = ({ className, ...props }: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M14.4016 8.0001C14.4016 9.69748 13.7273 11.3253 12.527 12.5256C11.3268 13.7258 9.69895 14.4001 8.00156 14.4001C6.30418 14.4001 4.67631 13.7258 3.47608 12.5256C2.27585 11.3253 1.60156 9.69748 1.60156 8.0001C1.60156 6.30271 2.27585 4.67485 3.47608 3.47461C4.67631 2.27438 6.30418 1.6001 8.00156 1.6001C9.69895 1.6001 11.3268 2.27438 12.527 3.47461C13.7273 4.67485 14.4016 6.30271 14.4016 8.0001ZM8.00156 4.0001C8.16069 4.0001 8.3133 4.06331 8.42583 4.17583C8.53835 4.28836 8.60156 4.44097 8.60156 4.6001V8.2001C8.60156 8.35923 8.53835 8.51184 8.42583 8.62436C8.3133 8.73688 8.16069 8.8001 8.00156 8.8001C7.84243 8.8001 7.68982 8.73688 7.5773 8.62436C7.46478 8.51184 7.40156 8.35923 7.40156 8.2001V4.6001C7.40156 4.44097 7.46478 4.28836 7.5773 4.17583C7.68982 4.06331 7.84243 4.0001 8.00156 4.0001ZM8.00156 12.0001C8.21374 12.0001 8.41722 11.9158 8.56725 11.7658C8.71728 11.6158 8.80156 11.4123 8.80156 11.2001C8.80156 10.9879 8.71728 10.7844 8.56725 10.6344C8.41722 10.4844 8.21374 10.4001 8.00156 10.4001C7.78939 10.4001 7.58591 10.4844 7.43588 10.6344C7.28585 10.7844 7.20156 10.9879 7.20156 11.2001C7.20156 11.4123 7.28585 11.6158 7.43588 11.7658C7.58591 11.9158 7.78939 12.0001 8.00156 12.0001Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+const PassIcon = ({ className, ...props }: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M8.00156 14.4001C9.69895 14.4001 11.3268 13.7258 12.527 12.5256C13.7273 11.3253 14.4016 9.69748 14.4016 8.0001C14.4016 6.30271 13.7273 4.67485 12.527 3.47461C11.3268 2.27438 9.69895 1.6001 8.00156 1.6001C6.30418 1.6001 4.67631 2.27438 3.47608 3.47461C2.27585 4.67485 1.60156 6.30271 1.60156 8.0001C1.60156 9.69748 2.27585 11.3253 3.47608 12.5256C4.67631 13.7258 6.30418 14.4001 8.00156 14.4001ZM11.0872 6.5529C11.1335 6.48913 11.1668 6.41686 11.1852 6.34021C11.2036 6.26357 11.2067 6.18405 11.1944 6.10619C11.1821 6.02834 11.1545 5.95368 11.1133 5.88647C11.0722 5.81926 11.0181 5.76083 10.9544 5.7145C10.8906 5.66817 10.8183 5.63485 10.7417 5.61645C10.665 5.59805 10.5855 5.59493 10.5077 5.60726C10.4298 5.61959 10.3551 5.64714 10.2879 5.68832C10.2207 5.72951 10.1623 5.78353 10.116 5.8473L7.32956 9.6793L5.82556 8.1753C5.77019 8.11802 5.70396 8.07234 5.63074 8.04093C5.55752 8.00952 5.47879 7.99301 5.39912 7.99235C5.31945 7.9917 5.24045 8.00692 5.16673 8.03712C5.093 8.06732 5.02603 8.11191 4.96972 8.16827C4.91342 8.22463 4.8689 8.29164 4.83876 8.36539C4.80863 8.43914 4.79348 8.51816 4.79421 8.59783C4.79494 8.67749 4.81153 8.75622 4.84301 8.8294C4.87449 8.90259 4.92023 8.96878 4.97756 9.0241L6.97756 11.0241C7.03886 11.0854 7.11273 11.1328 7.19408 11.1628C7.27543 11.1928 7.36232 11.2049 7.44877 11.1981C7.53522 11.1914 7.61918 11.1659 7.69487 11.1236C7.77055 11.0813 7.83615 11.023 7.88716 10.9529L11.0872 6.5529Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 export const getBenchmarkIcon = (benchmarkResult?: BenchmarkResult, className?: string) => {
   if (!benchmarkResult) {
     return <PendingIcon className={className} />;
@@ -44,9 +82,9 @@ export const getBenchmarkIcon = (benchmarkResult?: BenchmarkResult, className?: 
     case BenchmarkResults.Pass:
       return <PassIcon className={className} />;
     case BenchmarkResults.PartialPass:
-      return <PartialPassIcon className={className} />;
+      return <AlertIcon className={cn(className, "text-orange-500")} />;
     case BenchmarkResults.Fail:
-      return <FailIcon className={className} />;
+      return <AlertIcon className={cn(className, "text-red-500")} />;
 
     case BenchmarkResults.NotApplicable:
       return <NotApplicableIcon className={className} />;
@@ -57,7 +95,27 @@ export const getBenchmarkIcon = (benchmarkResult?: BenchmarkResult, className?: 
   }
 };
 
-export function BenchmarkResultBadge({ benchmarkResult, className }: BenchmarkResultBadgeProps) {
+const formatBenchmarkResultBadgeText = ({
+  benchmarkResult,
+  successRatio,
+}: Omit<BenchmarkResultBadgeProps, "className">) => {
+  if (successRatio !== undefined && benchmarkResult === BenchmarkResults.PartialPass) {
+    if (successRatio.testsPassed > successRatio.allTests) {
+      throw new Error(
+        `Invariant(BenchmarkSuccessRatio): testsPassed (${successRatio.testsPassed}) must be less than or equal to allTests (${successRatio.allTests})`,
+      );
+    }
+    return `${successRatio.allTests - successRatio.testsPassed}/${successRatio.allTests} tests failed`;
+  }
+
+  return formatBenchmarkResult(benchmarkResult, { lowercase: false });
+};
+
+export function BenchmarkResultBadge({
+  benchmarkResult,
+  successRatio,
+  className,
+}: BenchmarkResultBadgeProps) {
   const BenchmarkIcon = getBenchmarkIcon(benchmarkResult, "w-4 h-4 shrink-0");
   return (
     <span
@@ -69,7 +127,7 @@ export function BenchmarkResultBadge({ benchmarkResult, className }: BenchmarkRe
       )}
     >
       {BenchmarkIcon}
-      {formatBenchmarkResult(benchmarkResult, { lowercase: false })}
+      {formatBenchmarkResultBadgeText({ benchmarkResult, successRatio })}
     </span>
   );
 }

--- a/ensawards.org/src/components/atoms/badges/BenchmarkResultBadge.tsx
+++ b/ensawards.org/src/components/atoms/badges/BenchmarkResultBadge.tsx
@@ -1,7 +1,7 @@
 import {
+  type BenchmarkFailRatio,
   type BenchmarkResult,
   BenchmarkResults,
-  type BenchmarkSuccessRatio,
 } from "data/benchmarks/types.ts";
 import { formatBenchmarkResult } from "data/benchmarks/utils.ts";
 import { CircleOff as NotApplicableIcon, Clock as PendingIcon } from "lucide-react";
@@ -10,7 +10,7 @@ import { cn } from "@/utils/tailwindClassConcatenation";
 
 export interface BenchmarkResultBadgeProps {
   benchmarkResult?: BenchmarkResult;
-  successRatio?: BenchmarkSuccessRatio;
+  failRatio?: BenchmarkFailRatio;
   className?: string;
 }
 
@@ -97,23 +97,36 @@ export const getBenchmarkIcon = (benchmarkResult?: BenchmarkResult, className?: 
 
 const formatBenchmarkResultBadgeText = ({
   benchmarkResult,
-  successRatio,
+  failRatio,
 }: Omit<BenchmarkResultBadgeProps, "className">) => {
-  if (successRatio !== undefined && benchmarkResult === BenchmarkResults.PartialPass) {
-    if (successRatio.testsPassed > successRatio.allTests) {
-      throw new Error(
-        `Invariant(BenchmarkSuccessRatio): testsPassed (${successRatio.testsPassed}) must be less than or equal to allTests (${successRatio.allTests})`,
-      );
-    }
-    return `${successRatio.allTests - successRatio.testsPassed}/${successRatio.allTests} tests failed`;
+  const defaultText = formatBenchmarkResult(benchmarkResult, { lowercase: false });
+
+  if (failRatio === undefined) {
+    return defaultText;
   }
 
-  return formatBenchmarkResult(benchmarkResult, { lowercase: false });
+  if (benchmarkResult !== BenchmarkResults.PartialPass) {
+    return defaultText;
+  }
+
+  // For cases where all benchmarks have `BenchmarkResults.PartialPass`
+  // we will display the default partial pass label.
+  if (failRatio.benchmarksFailed === 0) {
+    return defaultText;
+  }
+
+  if (failRatio.benchmarksFailed > failRatio.allBenchmarks) {
+    throw new Error(
+      `Invariant(BenchmarkFailRatio): testsFailed (${failRatio.benchmarksFailed}) must be less than or equal to allTests (${failRatio.allBenchmarks})`,
+    );
+  }
+
+  return `${failRatio.benchmarksFailed}/${failRatio.allBenchmarks} tests failed`;
 };
 
 export function BenchmarkResultBadge({
   benchmarkResult,
-  successRatio,
+  failRatio,
   className,
 }: BenchmarkResultBadgeProps) {
   const BenchmarkIcon = getBenchmarkIcon(benchmarkResult, "w-4 h-4 shrink-0");
@@ -127,7 +140,7 @@ export function BenchmarkResultBadge({
       )}
     >
       {BenchmarkIcon}
-      {formatBenchmarkResultBadgeText({ benchmarkResult, successRatio })}
+      {formatBenchmarkResultBadgeText({ benchmarkResult, failRatio })}
     </span>
   );
 }

--- a/ensawards.org/src/components/atoms/cards/BenchmarkSummaryCard.astro
+++ b/ensawards.org/src/components/atoms/cards/BenchmarkSummaryCard.astro
@@ -6,7 +6,7 @@ import { type BestPracticeApp } from "data/ens-best-practices/types.ts";
 import { cn } from "@/utils/tailwindClassConcatenation";
 import {
   getAcceptanceTestBenchmarkLastUpdateTimestamp,
-  calcBenchmarkSuccessRatio,
+  calcBenchmarkFailRatio,
 } from "data/benchmarks/utils.ts";
 import { BenchmarkResultBadge } from "../badges/BenchmarkResultBadge";
 import { generalizeAcceptanceTestBenchmarks } from "data/acceptance-tests/utils.ts";
@@ -34,7 +34,7 @@ const detailValueStyles = cn(
 const generalizedAcceptanceTestsBenchmarkResult =
   generalizeAcceptanceTestBenchmarks(acceptanceTestBenchmarks);
 
-const acceptanceTestsBenchmarksSuccessRatio = calcBenchmarkSuccessRatio(acceptanceTestBenchmarks);
+const acceptanceTestsBenchmarksFailRatio = calcBenchmarkFailRatio(acceptanceTestBenchmarks);
 ---
 
 <div
@@ -68,7 +68,7 @@ const acceptanceTestsBenchmarksSuccessRatio = calcBenchmarkSuccessRatio(acceptan
       <p class={detailLabelStyles}>Acceptance test results</p>
       <BenchmarkResultBadge
         benchmarkResult={generalizedAcceptanceTestsBenchmarkResult}
-        successRatio={acceptanceTestsBenchmarksSuccessRatio}
+        failRatio={acceptanceTestsBenchmarksFailRatio}
       />
     </div>
     {

--- a/ensawards.org/src/components/atoms/cards/BenchmarkSummaryCard.astro
+++ b/ensawards.org/src/components/atoms/cards/BenchmarkSummaryCard.astro
@@ -4,18 +4,21 @@ import { RelativeTime } from "@namehash/namehash-ui";
 import { type AcceptanceTestBenchmarks } from "data/benchmarks/types.ts";
 import { type BestPracticeApp } from "data/ens-best-practices/types.ts";
 import { cn } from "@/utils/tailwindClassConcatenation";
-import { getAcceptanceTestBenchmarkLastUpdateTimestamp } from "data/benchmarks/utils.ts";
+import {
+  getAcceptanceTestBenchmarkLastUpdateTimestamp,
+  calcBenchmarkSuccessRatio,
+} from "data/benchmarks/utils.ts";
 import { BenchmarkResultBadge } from "../badges/BenchmarkResultBadge";
 import { generalizeAcceptanceTestBenchmarks } from "data/acceptance-tests/utils.ts";
 
 export interface BenchmarkSummaryCardProps {
   bestPractice: BestPracticeApp;
-  acceptanceTestsBenchmarks: AcceptanceTestBenchmarks;
+  acceptanceTestBenchmarks: AcceptanceTestBenchmarks;
 }
 
-const { bestPractice, acceptanceTestsBenchmarks }: BenchmarkSummaryCardProps = Astro.props;
+const { bestPractice, acceptanceTestBenchmarks }: BenchmarkSummaryCardProps = Astro.props;
 
-const benchmarksUpdateTimes = Object.values(acceptanceTestsBenchmarks)
+const benchmarksUpdateTimes = Object.values(acceptanceTestBenchmarks)
   .filter((benchmark) => benchmark !== undefined)
   .map((benchmark) => getAcceptanceTestBenchmarkLastUpdateTimestamp(benchmark));
 
@@ -29,7 +32,9 @@ const detailValueStyles = cn(
 );
 
 const generalizedAcceptanceTestsBenchmarkResult =
-  generalizeAcceptanceTestBenchmarks(acceptanceTestsBenchmarks);
+  generalizeAcceptanceTestBenchmarks(acceptanceTestBenchmarks);
+
+const acceptanceTestsBenchmarksSuccessRatio = calcBenchmarkSuccessRatio(acceptanceTestBenchmarks);
 ---
 
 <div
@@ -63,6 +68,7 @@ const generalizedAcceptanceTestsBenchmarkResult =
       <p class={detailLabelStyles}>Acceptance test results</p>
       <BenchmarkResultBadge
         benchmarkResult={generalizedAcceptanceTestsBenchmarkResult}
+        successRatio={acceptanceTestsBenchmarksSuccessRatio}
       />
     </div>
     {

--- a/ensawards.org/src/components/atoms/cards/BenchmarksPerAppTypeCard.tsx
+++ b/ensawards.org/src/components/atoms/cards/BenchmarksPerAppTypeCard.tsx
@@ -1,7 +1,12 @@
 import { generalizeAcceptanceTestBenchmarks } from "data/acceptance-tests/utils";
 import type { App } from "data/apps/types.ts";
-import { formatAppType, getAppById } from "data/apps/utils.ts";
+import { formatAppType, getAppById, sortApps } from "data/apps/utils.ts";
 import type { AcceptanceTestBenchmarks } from "data/benchmarks/types";
+import {
+  calcBenchmarkSuccessRatio,
+  sortBenchmarkResults,
+  sortBenchmarkSuccessRatios,
+} from "data/benchmarks/utils";
 import type { BestPracticeApp } from "data/ens-best-practices/types";
 import { Fragment } from "react";
 
@@ -19,13 +24,30 @@ export interface BenchmarksPerAppTypeCardProps {
 
 export function BenchmarksPerAppTypeCard({ appsWithBenchmark }: BenchmarksPerAppTypeCardProps) {
   // A necessary step due to Astro Island's inner serialization logic
-  const resolvedAppsWithBenchmark = appsWithBenchmark.map(
-    ({ app, bestPractice, acceptanceTestBenchmarks }) => ({
+  const resolvedAppsWithBenchmark = appsWithBenchmark
+    .map(({ app, bestPractice, acceptanceTestBenchmarks }) => ({
       app: getAppById(app.id) ?? app,
       bestPractice,
       acceptanceTestBenchmarks,
-    }),
-  );
+      generalizedBenchmarkResult: generalizeAcceptanceTestBenchmarks(acceptanceTestBenchmarks),
+      acceptanceTestsBenchmarksSuccessRatio: calcBenchmarkSuccessRatio(acceptanceTestBenchmarks),
+    }))
+    // sort the apps by their generalized benchmark result, then by success ratio, and finally by their name
+    .sort((a, b) => {
+      const benchmarkResultsDiff = sortBenchmarkResults(
+        a.generalizedBenchmarkResult,
+        b.generalizedBenchmarkResult,
+      );
+      if (benchmarkResultsDiff !== 0) return benchmarkResultsDiff;
+
+      const successRatioDiff = sortBenchmarkSuccessRatios(
+        a.acceptanceTestsBenchmarksSuccessRatio,
+        b.acceptanceTestsBenchmarksSuccessRatio,
+      );
+      if (successRatioDiff !== 0) return successRatioDiff;
+
+      return a.app.name.localeCompare(b.app.name);
+    });
 
   if (resolvedAppsWithBenchmark.length === 0) return null;
 
@@ -42,32 +64,42 @@ export function BenchmarksPerAppTypeCard({ appsWithBenchmark }: BenchmarksPerApp
         {formatAppType(firstApp.type, { plural: false, lowercase: false })} benchmarks
       </h3>
       <div className="flex w-full flex-col items-center">
-        {resolvedAppsWithBenchmark.map(({ app, bestPractice, acceptanceTestBenchmarks }, index) => {
-          const AppIcon = app.icon;
-          const generalizedBenchmarkResult =
-            generalizeAcceptanceTestBenchmarks(acceptanceTestBenchmarks);
+        {resolvedAppsWithBenchmark.map(
+          (
+            {
+              app,
+              bestPractice,
+              acceptanceTestBenchmarks,
+              generalizedBenchmarkResult,
+              acceptanceTestsBenchmarksSuccessRatio,
+            },
+            index,
+          ) => {
+            const AppIcon = app.icon;
 
-          return (
-            <Fragment key={`${app.id}-${bestPractice.id}`}>
-              <a
-                href={`/app/${app.appSlug}/${bestPractice.category.categorySlug}/${bestPractice.bestPracticeSlug}`}
-                className="flex w-full items-center gap-3 py-4 p-[10px] rounded-xl transition-colors duration-200 hover:bg-[#F5F5F5]"
-              >
-                <AppIcon className="h-8 w-8 shrink-0 rounded-md" />
-                <span className="min-w-0 flex-1 text-base leading-normal font-semibold text-neutral-900">
-                  {app.name}
-                </span>
-                <BenchmarkResultBadge
-                  benchmarkResult={generalizedBenchmarkResult}
-                  className="shrink-0 cursor-pointer"
-                />
-              </a>
-              {index < appsWithBenchmark.length - 1 && (
-                <div className="w-[calc(100%-28px)] h-[1px] bg-[#F5F5F5]" />
-              )}
-            </Fragment>
-          );
-        })}
+            return (
+              <Fragment key={`${app.id}-${bestPractice.id}`}>
+                <a
+                  href={`/app/${app.appSlug}/${bestPractice.category.categorySlug}/${bestPractice.bestPracticeSlug}`}
+                  className="flex w-full items-center gap-3 py-4 p-[10px] rounded-xl transition-colors duration-200 hover:bg-[#F5F5F5]"
+                >
+                  <AppIcon className="h-8 w-8 shrink-0 rounded-md" />
+                  <span className="min-w-0 flex-1 text-base leading-normal font-semibold text-neutral-900 max-[360px]:break-words">
+                    {app.name}
+                  </span>
+                  <BenchmarkResultBadge
+                    benchmarkResult={generalizedBenchmarkResult}
+                    successRatio={acceptanceTestsBenchmarksSuccessRatio}
+                    className="shrink-0 cursor-pointer"
+                  />
+                </a>
+                {index < appsWithBenchmark.length - 1 && (
+                  <div className="w-[calc(100%-28px)] h-[1px] bg-[#F5F5F5]" />
+                )}
+              </Fragment>
+            );
+          },
+        )}
       </div>
     </div>
   );

--- a/ensawards.org/src/components/atoms/cards/BenchmarksPerAppTypeCard.tsx
+++ b/ensawards.org/src/components/atoms/cards/BenchmarksPerAppTypeCard.tsx
@@ -3,9 +3,9 @@ import type { App } from "data/apps/types.ts";
 import { formatAppType, getAppById } from "data/apps/utils.ts";
 import type { AcceptanceTestBenchmarks } from "data/benchmarks/types";
 import {
-  calcBenchmarkSuccessRatio,
+  calcBenchmarkFailRatio,
+  sortBenchmarkFailRatios,
   sortBenchmarkResults,
-  sortBenchmarkSuccessRatios,
 } from "data/benchmarks/utils";
 import type { BestPracticeApp } from "data/ens-best-practices/types";
 import { Fragment } from "react";
@@ -30,9 +30,9 @@ export function BenchmarksPerAppTypeCard({ appsWithBenchmark }: BenchmarksPerApp
       bestPractice,
       acceptanceTestBenchmarks,
       generalizedBenchmarkResult: generalizeAcceptanceTestBenchmarks(acceptanceTestBenchmarks),
-      acceptanceTestsBenchmarksSuccessRatio: calcBenchmarkSuccessRatio(acceptanceTestBenchmarks),
+      acceptanceTestsBenchmarksFailRatio: calcBenchmarkFailRatio(acceptanceTestBenchmarks),
     }))
-    // sort the apps by their generalized benchmark result, then by success ratio, and finally by their name
+    // sort the apps by their generalized benchmark result, then by fail ratio, and finally by their name
     .sort((a, b) => {
       const benchmarkResultsDiff = sortBenchmarkResults(
         a.generalizedBenchmarkResult,
@@ -40,11 +40,11 @@ export function BenchmarksPerAppTypeCard({ appsWithBenchmark }: BenchmarksPerApp
       );
       if (benchmarkResultsDiff !== 0) return benchmarkResultsDiff;
 
-      const successRatioDiff = sortBenchmarkSuccessRatios(
-        a.acceptanceTestsBenchmarksSuccessRatio,
-        b.acceptanceTestsBenchmarksSuccessRatio,
+      const failRatioDiff = sortBenchmarkFailRatios(
+        a.acceptanceTestsBenchmarksFailRatio,
+        b.acceptanceTestsBenchmarksFailRatio,
       );
-      if (successRatioDiff !== 0) return successRatioDiff;
+      if (failRatioDiff !== 0) return failRatioDiff;
 
       return a.app.name.localeCompare(b.app.name);
     });
@@ -66,12 +66,7 @@ export function BenchmarksPerAppTypeCard({ appsWithBenchmark }: BenchmarksPerApp
       <div className="flex w-full flex-col items-center">
         {resolvedAppsWithBenchmark.map(
           (
-            {
-              app,
-              bestPractice,
-              generalizedBenchmarkResult,
-              acceptanceTestsBenchmarksSuccessRatio,
-            },
+            { app, bestPractice, generalizedBenchmarkResult, acceptanceTestsBenchmarksFailRatio },
             index,
           ) => {
             const AppIcon = app.icon;
@@ -88,7 +83,7 @@ export function BenchmarksPerAppTypeCard({ appsWithBenchmark }: BenchmarksPerApp
                   </span>
                   <BenchmarkResultBadge
                     benchmarkResult={generalizedBenchmarkResult}
-                    successRatio={acceptanceTestsBenchmarksSuccessRatio}
+                    failRatio={acceptanceTestsBenchmarksFailRatio}
                     className="shrink-0 cursor-pointer"
                   />
                 </a>

--- a/ensawards.org/src/components/atoms/cards/BenchmarksPerAppTypeCard.tsx
+++ b/ensawards.org/src/components/atoms/cards/BenchmarksPerAppTypeCard.tsx
@@ -1,6 +1,6 @@
 import { generalizeAcceptanceTestBenchmarks } from "data/acceptance-tests/utils";
 import type { App } from "data/apps/types.ts";
-import { formatAppType, getAppById, sortApps } from "data/apps/utils.ts";
+import { formatAppType, getAppById } from "data/apps/utils.ts";
 import type { AcceptanceTestBenchmarks } from "data/benchmarks/types";
 import {
   calcBenchmarkSuccessRatio,
@@ -69,7 +69,6 @@ export function BenchmarksPerAppTypeCard({ appsWithBenchmark }: BenchmarksPerApp
             {
               app,
               bestPractice,
-              acceptanceTestBenchmarks,
               generalizedBenchmarkResult,
               acceptanceTestsBenchmarksSuccessRatio,
             },

--- a/ensawards.org/src/components/molecules/technicalDetails/bestPractice/index.tsx
+++ b/ensawards.org/src/components/molecules/technicalDetails/bestPractice/index.tsx
@@ -32,7 +32,7 @@ export const BestPracticeTechnicalDetails = ({
   });
 
   return (
-    <div className="max-w-[716px] flex flex-nowrap flex-col justify-center items-start gap-6">
+    <div className="w-full max-w-[716px] flex flex-nowrap flex-col justify-center items-start gap-6">
       <div className={technicalSectionContainerStyles}>
         <h2 className={technicalSectionHeaderStyles}>ENS best practice overview</h2>
         <EnsBestPracticeOverview bestPractice={bestPractice} />

--- a/ensawards.org/src/components/organisms/AppBestPracticeDetails.astro
+++ b/ensawards.org/src/components/organisms/AppBestPracticeDetails.astro
@@ -118,9 +118,9 @@ const additionalInfoContainerStyles =
 <section
   class="w-full box-border h-fit flex flex-col flex-nowrap justify-start items-center py-6 sm:py-[60px] px-5 sm:px-8">
   <div
-    class="w-full max-w-[1216px] flex flex-nowrap flex-col md:flex-row gap-6 md:gap-20 justify-start md:justify-center items-start">
+    class="w-full max-w-[1216px] flex flex-nowrap flex-col min-[850px]:flex-row gap-6 min-[850px]:gap-20 justify-start min-[850px]:justify-between items-start">
     <BestPracticeTechnicalDetails bestPractice={bestPractice} />
-    <div class="w-full md:w-1/2 h-fit box-border flex flex-col gap-5">
+    <div class="w-full min-[850px]:w-1/2 h-fit box-border flex flex-col gap-5">
       <ContributorsCard
         client:only="react"
         sidebarVariant

--- a/ensawards.org/src/components/organisms/ProtocolBestPracticeDetails.astro
+++ b/ensawards.org/src/components/organisms/ProtocolBestPracticeDetails.astro
@@ -91,11 +91,11 @@ const additionalInfoContainerStyles =
   class="w-full box-border h-fit flex flex-col flex-nowrap justify-start items-center gap-6 sm:gap-10 py-6 sm:pt-[60px] px-5 sm:px-8">
   <ContractNamingBanner />
   <div
-    class="w-full max-w-[1216px] flex flex-nowrap flex-col sm:flex-row gap-6 sm:gap-20 justify-start sm:justify-center items-start">
+    class="w-full max-w-[1216px] flex flex-nowrap flex-col min-[850px]:flex-row gap-6 min-[850px]:gap-20 justify-start min-[850px]:justify-between items-start">
     <BestPracticeTechnicalDetails bestPractice={bestPractice} />
-    <div class="w-full sm:w-1/2 h-fit box-border flex flex-col gap-5">
+    <div class="w-full min-[850px]:w-1/2 h-fit box-border flex flex-col gap-5">
       <div
-        class="w-full min-w-[300px] max-w-[420px] box-border h-fit hidden sm:flex flex-col flex-nowrap justify-center items-start gap-4 bg-gray-50 rounded-xl py-5 px-6">
+        class="w-full min-w-[300px] max-w-[420px] box-border h-fit hidden min-[850px]:flex flex-col flex-nowrap justify-center items-start gap-4 bg-gray-50 rounded-xl py-5 px-6">
         <h4
           class={cn(
             technicalSectionMinorHeaderStyles,

--- a/ensawards.org/src/pages/app/[appSlug]/[categorySlug]/[bestPracticeSlug]/index.astro
+++ b/ensawards.org/src/pages/app/[appSlug]/[categorySlug]/[bestPracticeSlug]/index.astro
@@ -119,7 +119,7 @@ if (app !== undefined && bestPractice !== undefined) {
           <div class="w-full lg:w-1/3 h-fit box-border flex flex-col gap-5">
             <BenchmarkSummaryCard
               bestPractice={bestPractice}
-              acceptanceTestsBenchmarks={appAcceptanceTestBenchmarks}>
+              acceptanceTestBenchmarks={appAcceptanceTestBenchmarks}>
               <div slot="appInfo" class="flex h-7 items-center gap-3">
                 <AppIcon className="w-[28px] h-[28px] shrink-0 rounded-[6px]" />
                 <a

--- a/ensawards.org/src/pages/app/[appSlug]/index.astro
+++ b/ensawards.org/src/pages/app/[appSlug]/index.astro
@@ -23,7 +23,7 @@ import {
   calcBestPracticeCategoryScore,
   sortBenchmarkResults,
   getAppBenchmarks,
-  calcBenchmarkSuccessRatio,
+  calcBenchmarkFailRatio,
 } from "data/benchmarks/utils";
 import type { BestPracticeBenchmarks } from "data/ens-best-practices/types";
 import { EnsAwardsCircularScoreSmall } from "@/components/atoms/ens-awards-score/circular-small.tsx";
@@ -149,9 +149,7 @@ if (app !== undefined) {
                         bestPracticeSlug,
                         bestPracticeBenchmarks,
                       ),
-                      successRatio: calcBenchmarkSuccessRatio(
-                        bestPracticeBenchmarks,
-                      ),
+                      failRatio: calcBenchmarkFailRatio(bestPracticeBenchmarks),
                     }))
                     .sort((a, b) =>
                       sortBenchmarkResults(
@@ -174,7 +172,7 @@ if (app !== undefined) {
                         ({
                           bestPractice,
                           generalizedBenchmarkResult,
-                          successRatio,
+                          failRatio,
                         }) => {
                           return (
                             <BenchmarkResultCard
@@ -187,7 +185,7 @@ if (app !== undefined) {
                                 slot="badge"
                                 className="cursor-pointer"
                                 benchmarkResult={generalizedBenchmarkResult}
-                                successRatio={successRatio}
+                                failRatio={failRatio}
                               />
                             </BenchmarkResultCard>
                           );

--- a/ensawards.org/src/pages/app/[appSlug]/index.astro
+++ b/ensawards.org/src/pages/app/[appSlug]/index.astro
@@ -23,6 +23,7 @@ import {
   calcBestPracticeCategoryScore,
   sortBenchmarkResults,
   getAppBenchmarks,
+  calcBenchmarkSuccessRatio,
 } from "data/benchmarks/utils";
 import type { BestPracticeBenchmarks } from "data/ens-best-practices/types";
 import { EnsAwardsCircularScoreSmall } from "@/components/atoms/ens-awards-score/circular-small.tsx";
@@ -143,12 +144,15 @@ if (app !== undefined) {
                   const benchmarksOnBestPractice = [
                     ...Object.entries(benchmarksInCategory),
                   ]
-                    .map(([bestPracticeSlug, bestPracticeBenchmarks]) =>
-                      summarizeAppsAcceptanceTestBenchmarks(
+                    .map(([bestPracticeSlug, bestPracticeBenchmarks]) => ({
+                      ...summarizeAppsAcceptanceTestBenchmarks(
                         bestPracticeSlug,
                         bestPracticeBenchmarks,
                       ),
-                    )
+                      successRatio: calcBenchmarkSuccessRatio(
+                        bestPracticeBenchmarks,
+                      ),
+                    }))
                     .sort((a, b) =>
                       sortBenchmarkResults(
                         a.generalizedBenchmarkResult,
@@ -167,7 +171,11 @@ if (app !== undefined) {
                         </span>
                       </div>
                       {benchmarksOnBestPractice.map(
-                        ({ bestPractice, generalizedBenchmarkResult }) => {
+                        ({
+                          bestPractice,
+                          generalizedBenchmarkResult,
+                          successRatio,
+                        }) => {
                           return (
                             <BenchmarkResultCard
                               bestPractice={bestPractice}
@@ -179,6 +187,7 @@ if (app !== undefined) {
                                 slot="badge"
                                 className="cursor-pointer"
                                 benchmarkResult={generalizedBenchmarkResult}
+                                successRatio={successRatio}
                               />
                             </BenchmarkResultCard>
                           );


### PR DESCRIPTION
# Lite PR &rarr;  Refine UI/UX of generalized benchmark result display

## Summary

* Refined **`ensawards.org/src/components/atoms/badges/BenchmarkResultBadge.tsx`** component according to the latest Figma designs, with consideration that the previous display is still relevant when it comes to a singular acceptance test benchmark
* Added new utility types, functions, and unit tests
* Adapted all places of usage where the new display was required
* Applied minor layout fixes for average screen sizes (640-850px) after the UI verification

---

## Why

- Requested by @lightwalker-eth [here](https://namehash.slack.com/archives/C086Z6FNBHN/p1782191128734529)

---

## Testing

- Ran `typecheck`, `lint`, and `test` commands locally to ensure that the migration didn't break anything, and later confirmed that in our CI workflow
- Verified that the UI didn't break after introducing changes using a local and Vercel previews.

---

## Notes for reviewer

* Left two follow-up questions [here](https://namehash.slack.com/archives/C086Z6FNBHN/p1782200977288819?thread_ts=1782191128.734529&cid=C086Z6FNBHN) (`UPDATE: now resolved`)

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.